### PR TITLE
Protocol Revision Proposal: Root CID, Partial Response, Block Metadata

### DIFF
--- a/graphsync/graphsync.md
+++ b/graphsync/graphsync.md
@@ -68,11 +68,6 @@ message GraphsyncMessage {
     bool  cancel = 5;   // whether this cancels a request
   }
 
-  message RequestList {
-    repeated Request reqs = 1; // a list of requests
-    bool full = 2;			   // whether this is the full RequestList. default to false, for incremental requests.
-  }
-
   message Response {
     int32 id = 1;     // the request id
     int32 status = 2; // a status code.
@@ -85,9 +80,10 @@ message GraphsyncMessage {
   }
 
   // the actual data included in this message
-  RequestList reqlist = 1;
-  repeated Response reslist = 2;
-  repeated Block data = 2;
+  bool completeRequestList    = 1; // This request list includes *all* requests, replacing outstanding requests.
+  repeated Request  requests  = 2; // The list of requests.
+  repeated Response responses = 3; // The list of responses.
+  repeated Block    data      = 4; // Blocks related to the responses
 }
 ```
 

--- a/graphsync/graphsync.md
+++ b/graphsync/graphsync.md
@@ -105,6 +105,7 @@ message GraphsyncMessage {
 11   Additional Peers. PeerIDs in extra.
 12   Not enough vespene gas ($)
 13   Other Protocol - info in extra.
+14   Partial Response, may include blocks and metadata
 
 # success - terminal
 20   Request Completed, full content.

--- a/graphsync/graphsync.md
+++ b/graphsync/graphsync.md
@@ -76,16 +76,24 @@ message GraphsyncMessage {
     bytes extra = 3;
   }
 
+  message BlockMetadata {
+    int32 id = 1; // the request id
+    bytes block = 2; // CID for block this metadata refers to
+    repeated string path = 3; // IPLD path for this block from root
+    bytes control_message = 4; // information about this CID, such as it being missing
+  }
+
   message Block {
   	bytes prefix = 1; // CID prefix (cid version, multicodec and multihash prefix (type + length)
   	bytes data = 2;
   }
 
   // the actual data included in this message
-  bool completeRequestList    = 1; // This request list includes *all* requests, replacing outstanding requests.
-  repeated Request  requests  = 2; // The list of requests.
-  repeated Response responses = 3; // The list of responses.
-  repeated Block    data      = 4; // Blocks related to the responses
+  bool completeRequestList         = 1; // This request list includes *all* requests, replacing outstanding requests.
+  repeated Request       requests  = 2; // The list of requests.
+  repeated Response      responses = 3; // The list of responses.
+  repeated Block         data      = 4; // Blocks related to the responses
+  repeated BlockMetadata metadata  = 5; 
 }
 ```
 

--- a/graphsync/graphsync.md
+++ b/graphsync/graphsync.md
@@ -43,6 +43,7 @@ type Graphsync interface {
 }
 
 type Request struct {
+    Root     Cid
     Selector Selector
     Priority Priority      // optional
     Expires  time.Duration // optional
@@ -62,10 +63,11 @@ message GraphsyncMessage {
 
   message Request {
     int32 id = 1;       // unique id set on the requester side
-    bytes selector = 2; // ipld selector to retrieve
-    bytes extra = 3;    // aux information. useful for other protocols
-    int32 priority = 4;	// the priority (normalized). default to 1
-    bool  cancel = 5;   // whether this cancels a request
+    bytes root = 2;     // root CID from which to apply the selector
+    bytes selector = 3; // ipld selector to retrieve
+    bytes extra = 4;    // aux information. useful for other protocols
+    int32 priority = 5;	// the priority (normalized). default to 1
+    bool  cancel = 6;   // whether this cancels a request
   }
 
   message Response {


### PR DESCRIPTION
This proposal makes three changes to the wire protocol to support current thinking on how the first implemented version of the selector interface will work.

1. Add a root CID to the request. Current thinking suggests a root CID is neccesary to begin a request, and absolute selectors will not be supported in the first version of IPLD selector interfaces (at least in go)

2. Add a response code for an in-progress partial response. The responder may want to begin sending response blocks and information before it completes the request, so that it doesn't a huge amount of blocks in memory for a large selection. This is different than a request acknowledged response code (10) in that it contains actual blocks and metadata. It is different that a terminal response with partial data (20), in that it indicates more data is coming-- this is not the last response this responder will send.

3. Add a block metadata structure. This serves two purposes. If a responder is servicing more than one request, it should not send the same block twice for bandwidth reasons. The same is true if the same block appears multiple times in a selection for whatever reason. However, simply sending the blocks provides little information about how they tie to a request, where they sit in the IPLD path relative to the root, or any other information that we may want to communicate to the requester. We may also need to communicate information about a block we don't have -- so that the requester knows that is missing in the response and it can go seek it elsewhere. The metadata block contains:

```
1. A request ID
2. A CID for a block
3. The path for that block in the context of a selection
4. A control message about that block for additional information that can be decoded by IPLD.
```

Importantly, there can be more than one metadata for a given block over the course of the request.

From @warpfork in https://github.com/ipld/specs/issues/90#issuecomment-462029414 -- provides some of the rationale for adding this metadata

```
It's possible that the state machines on both sides of this process could be implemented without extra control messages to mark things like these blocks which we're including despite not matching. I'm uncommitted to whether or not that's a _good_ idea even if it's _possible_ -- this seems like a situation where a little more contextualization information might be extremely useful for development and debugging, sanity checks, meaningful error reports, and future proofing.
```
