### PR TITLE
RFC: Graphsync Response Metadata

### DIFF
--- a/block-layer/graphsync/graphsync.md
+++ b/block-layer/graphsync/graphsync.md
@@ -74,7 +74,8 @@ message GraphsyncMessage {
   message Response {
     int32 id = 1;     // the request id
     int32 status = 2; // a status code.
-    bytes extra = 3;
+    bytes metadata = 3; // metadata about response
+    bytes extra = 4;
   }
 
   message Block {
@@ -90,6 +91,37 @@ message GraphsyncMessage {
 }
 ```
 
+### Response Metadata
+
+Response metadata provides information about the response to help the requestor more efficiently verify the blocks sent back from the responder are valid for the requested IPLD selector. It contains information about the CIDs the responder traversed, in order, during the course of performing the selector query and whether or not the corresponding block was present in its local block store.
+
+It is an IPLD node of the format:
+
+```json
+[
+  {
+    "link": "cidabcdef",
+    "blockPresent": true
+  },
+  {
+    "link": "abcdedf443",
+    "blockPresent": false
+  },
+  ...
+]
+```
+
+or in IPLD Schema:
+
+```ipldsch
+type LinkMetadata struct {
+  link Cid
+  blockPresent Bool
+}
+
+type ResponseMetadata [LinkMetadata]
+```
+
 ### Response Status Codes
 
 ```
@@ -98,7 +130,7 @@ message GraphsyncMessage {
 11   Additional Peers. PeerIDs in extra.
 12   Not enough vespene gas ($)
 13   Other Protocol - info in extra.
-14   Partial Response w/ metadata, may include blocks, metadata in extra
+14   Partial Response w/ metadata, may include blocks
 
 # success - terminal
 20   Request Completed, full content.


### PR DESCRIPTION
This PR serves as a follow up to #97 

Specifically that PR states:

---

The proposal for the initial go implementation, in order to optimize memory usage, is to instead have the server send blocks as soon as it finds them, as well as information about what blocks are not available as soon as it knows. Then the client will verify and return blocks to the graphsync caller as soon as it receives them.

To support this, I'm proposing adding a "partial response" code. When this response code is transmitted, the "extra" field of the response becomes metadata about what has been transmitted -- either CIDs of blocks that are included in the response, or CIDs the server knows it doesn't have, or other control messages. For the moment, the content and structure of this extra data is left intentionally ambiguous, because more potential use cases may emerge during the actual implementation of go-graphsync and the IPLD selector library. It's structure will likely be specified more concretely once an implementation has been completed.

---

Having progressed farther on the implementation of GraphSync, I want to surface the actual structure of the "extra data" sent back in a partial response -- what I call response metadata, and ask whether it should specifically become part of the specification. Moreover, I recently learned that the `extra` field is intended to transmit side channel protocol information, such as payments, and I wonder whether using it to transmit this bit of metadata is overloading the purpose of the field. I'm wondering if it makes better sense to add one more field to a response called `metadata` and put it there.
