### PR TITLE
dag-pb-spec: steb CR

### DIFF
--- a/Codecs/DAG-PB.md
+++ b/Codecs/DAG-PB.md
@@ -10,10 +10,10 @@ The DAG-PB IPLD format is a legacy format implemented with a single protobuf.
 // An IPFS MerkleDAG Link
 message PBLink {
 
-  // multihash of the target object
+  // binary CID (with no multibase prefix) of the target object
   optional bytes Hash = 1;
 
-  // utf string name. should be unique per object
+  // UTF-8 string name.
   optional string Name = 2;
 
   // cumulative size of target object
@@ -32,24 +32,69 @@ message PBNode {
 ```
 
 The objects link names are specified in the 'Name' field of the PBLink object.
-This is non-standard and means that the 'Tsize' attribute of a link, and
-neither the 'Data' field nor the 'Links' field of the PBNode are available
-through the ipld query language. 
+All links in an object must either be blank or unique within the object.
 
-## Link Format
+## Pathing
 
-In DagCBOR, links are encoded using the raw-binary (identity, NUL) multibase in a
-field with a byte-string type (major type 2), with the tag 42. They are then
-put in the 'Hash' field of a PBLink. All links from a DAG-PB object are
-specified in the 'Links' array.
+TODO: See https://github.com/ipld/specs/issues/55
+TODO: Also see https://github.com/ipfs/unixfs-v2/issues/24 (specifically: the "Revise History" option).
+
+Neither go-ipfs nor js-ipfs agree so we have some room here because we're going to break something.
+
+### Alternative: go-ipfs
+
+In go-ipfs, we resolve use link names directly in paths: `/$name1/$name2/...`.
+Neither the Data section nor the Links section/metadata are accessible through
+paths.
+
+It's also impossible to path through nodes that don't name their links.
+
+### Alternative: js-ipfs
+
+As far as I can tell, js-ipfs supports pathing both by name and by index with
+paths like: `/Links/$name/Hash/...` or `/Links/$idx/Hash`.
+
+### Alternative: Correct IPLD
+
+Based purely on the _structure_, we should only support pathing by index. That
+is, `/Links/$idx/Hash`.
+
+### Alternative: Transform
+
+We could implicitly transform the protobuf to some new structure in the IPLD data model.
+
+1. If the object has no links, the "links" section is "null".
+2. If the object has links with names, all links must have unique names so we can treat links as a map:
+
+```
+{
+  "Data": ...,
+  "Links": {
+    "$name": {"target": Qm..., "size": ...}
+  }
+}
+```
+
+3. If the object has links without names, we can pack them into an array:
+
+```
+{
+  "Data": ...,
+  "Links": [
+    {"target": Qm..., "size": ...}
+  ]
+}
+```
 
 ## Canonical DAG-PB
 
 Canonical DAG-PB must:
 
 1. Contain only the specified protobuf fields.
-2. Use standard protobuf encoding, except that the 'Links' field must be before
-   the 'Data' field in the encoding. This is due to a bug in the initial
-   protobuf encoder that was used in the first implementation of ipfs.
-3. Only use string map keys. Some implementations may not be able to
-   handle non-string keys.
+2. Use standard protobuf encoding, with the following field orders:
+  - PBNode: Links, Data
+  - PBLink: Hash, Name, Tsize
+
+Historical Note: The ordering (Links then Data) of the PBNode message is due to
+a bug in the initial protobuf encoder that was used in the first implementation
+of ipfs. Take care to maintain this ordering for full compatibility.


### PR DESCRIPTION
1. Fix link/hash encoding (not CBOR).
2. Describe a bunch of options for pathing.
3. Expand on canonical encoding.