### PR TITLE
Selectors++ (recursive design)

### DIFF
--- a/selectors/selectors.md
+++ b/selectors/selectors.md
@@ -276,7 +276,6 @@ An example selector to get the full sub-DAG rooted at a certain CID:
 
 ```json
 {"selectRecursive": {
-  "depthLimit": 5,
   "next":
     {"selectFields":{"Links":
       {"selectAll":
@@ -292,7 +291,6 @@ If it's a file in some directory, you can also start at a deeper level:
   {"selectFields":{"some":
     {"selectFields":{"subdirectory":
       {"selectRecursive": {
-        "depthLimit": 5,
         "next":
           {"selectFields":{"Links":
             {"selectAll":


### PR DESCRIPTION
This set of specs is for a more recursive strategy of selectors, and is
much more expressive.

It's also, importantly, accompanied by a working proof-of-concept
implementation in the go-ipld-prime repo, which has kicked the tires.

Credit where it's due: the previous stuff, with its linear stack of
selectors, despite being 'git blame' to vmx, was mostly me; and this
stuff, which is much more excellent, is actually closer to what vmx was
originally proposing in our earlier discussions.
So in other words, I came around eventually :)

We turn out to have union selectors *in*!  This is remarkable because
it's a feature we were trying to avoid until future rounds.
The change of heart is because it turns out that unions are actually
a feature that's *implied* by some of the other selectors (namely,
recursives) when implemented internally... so the additional work to
then just expose that feature turns out to be negligible.  Tada!

This may still not be the final resting place of this spec.
I'm baking on another round of drafts which attempt to more fully
separate "matchers" vs "explorer" parameters -- you can see some of
this concept starting to show up in the docs already in this commit,
though it's not made fully concrete anywhere yet.  These drafts are
as-yet incomplete, but fueled by the hope that it may make some parts
of recursives a bit clearer... as well as leave us better set up for
future fancier node match conditions which can use logic that's
orthagonal from the exploration guidance.  But that's a mouthful.
We'll see.