### PR TITLE
Graphsync: add root cid

### DIFF
--- a/block-layer/graphsync/graphsync.md
+++ b/block-layer/graphsync/graphsync.md
@@ -64,10 +64,11 @@ message GraphsyncMessage {
 
   message Request {
     int32 id = 1;       // unique id set on the requester side
-    bytes selector = 2; // ipld selector to retrieve
-    bytes extra = 3;    // aux information. useful for other protocols
-    int32 priority = 4;	// the priority (normalized). default to 1
-    bool  cancel = 5;   // whether this cancels a request
+    bytes root = 2;     // a CID for the root node in the query
+    bytes selector = 3; // ipld selector to retrieve
+    bytes extra = 4;    // aux information. useful for other protocols
+    int32 priority = 5;	// the priority (normalized). default to 1
+    bool  cancel = 6;   // whether this cancels a request
   }
 
   message Response {


### PR DESCRIPTION
This is a companion PR to #116, which removes CIDS from selectors, making them entirely recursive. If PR #116 is accepted, Graphsync will need to treat the first CID lookup as seperate concern from performing a selector traversal. 

The PR proposes adding a CID root as a member in a graphsync request. Graphsync itself would then be responsible for using the loader function to look up and transmit the first block. This would not add a second round trip -- it would just mean Graphsync had to do a bit of extra work to actually look up the root node on the responder side.

The advantage is this allows #116, which would make selectors fully recursive.