### PR TITLE
Proposal: new version of dag-json

### DIFF
--- a/block-layer/codecs/DAG-JSON.md
+++ b/block-layer/codecs/DAG-JSON.md
@@ -14,14 +14,56 @@ Contrary to popular belief, JSON as a format supports Big Integers. It's only
 JavaScript itself that has trouble with them. This means JS implementations
 of `dag-json` can't use the native JSON parser and serializer.
 
+### Version 0
+
+This is an old version of `dag-json` that reserved the `"/"` key in order to
+represent binary and link data types.
+
 #### Binary Type
 
 ```javascript
 {"/": { "base64": String }}
 ```
 
-### Link Type
+#### Link Type
 
 ```javascript
 {"/": String /* base encoded CID */}
+```
+
+### Version 1
+
+#### Format
+
+The internal data format is valid JSON but is **NOT** identical to the decoded
+node data codecs produce.
+
+Example internal format:
+
+```javascript
+{ "/": { "_": 1 },
+  "data": { "hello": "world": { "obj": { "array": [0, 0] } } },
+  "meta": {
+    base64: [
+      [[ "key" ], "dmFsdWU="],
+      [[ "obj", "key"], "dmFsdWU="],
+      [[ "obj", "array", 0], "dmFsdWU="]
+    ],
+    links: [
+      [["obj", "array", 1], "zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA"]
+    ]
+  }
+}
+```
+
+Decodes to:
+
+```javascript
+{ hello: 'world',
+  key: Buffer.from('value'),
+  obj: {
+    array: [ Buffer.from('value'), new CID('zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA')],
+    key: Buffer.from('value')
+  }
+}
 ```

--- a/block-layer/codecs/DAG-JSON.md
+++ b/block-layer/codecs/DAG-JSON.md
@@ -42,7 +42,7 @@ Example internal format:
 
 ```javascript
 { "/": { "_": 1 },
-  "data": { "hello": "world": { "obj": { "array": [0, 0] } } },
+  "data": { "hello": "world", { "obj": { "array": [0, 0] } } },
   "meta": {
     base64: [
       [[ "key" ], "dmFsdWU="],


### PR DESCRIPTION
This spec change would resolve the outstanding issue of `dag-json` not being able to represent the “/“ key.

Since “/“ is already reserved, we use that key for the version definition, which makes this new version backwards compatible with all of the existing `dag-json` data.

This change would also set up `dag-json` to store data outside of the actual node data, which could be used similar to how tags are used in cbor or for something like https://github.com/ipld/js-generics/issues/3