### PR TITLE
Schema update: use implicits; also, more docs.

### DIFF
--- a/schema-layer/schemas/schema-dsl.md
+++ b/schema-layer/schemas/schema-dsl.md
@@ -1,0 +1,40 @@
+Schema DSL
+==========
+
+IPLD Schemas can be represented in a compact, human-friendly
+[DSL](https://en.wikipedia.org/wiki/Domain_specific_language).
+IPLD Schemas can also be naturally represented as an IPLD node graph;
+the human-friendly DSL compiles into this IPLD-native format.
+
+TODO:FUTURE: more exposition.
+
+
+Notes
+-----
+
+These errata document some of the finer details of the schema DSL
+which you don't need to read to get started, but may help clarify the
+internal logic of why some parts of the syntax look the way they do.
+
+### Parens after field descriptions
+
+For the most part,
+text in the "type" block describes properties of the type -- meaning: things
+which affect the cardinality and essence of how we treat the thing --
+and text in the "representation" block describes everything else -- meaning
+things which change how we map things into the Data Model, but conserve
+cardinality.
+
+Sometimes a line which describes a field in a struct has some additional
+text at the end of the line which is surrounded by parenthesis.
+These parenthesis denote that the contained text is actually "representation"
+description.  If we kept to the rule above, in order to specify information
+relating to a specific field down in the representation block, we'd end up
+repeating the field name.  The parenthesis are our solution to avoiding this
+textual redundancy, while also continuing to mark the difference between type
+and representational information.
+
+If you look at the IPLD-native format rather than the DSL, you'll see that
+the representation and type information remains in clearly separate trees,
+and does indeed repeat field names; this concession of the parenthesis is
+for the DSL's convenience only.

--- a/schema-layer/schemas/schema-schema.ipldsch
+++ b/schema-layer/schemas/schema-schema.ipldsch
@@ -164,20 +164,16 @@ type TypeFloat struct {}
 type TypeMap struct {
 	keyType TypeName # additionally, the referenced type must be reprkind==string.
 	valueType TypeTerm
-	valueNullable Bool
-} representation map {
-	field valueNullable default "false"
-}
+	valueNullable Bool (implicit "false")
+} representation map
 
 ## TypeList describes a list.
 ## The values of the list have some specific type of their own.
 ##
 type TypeList struct {
 	valueType TypeTerm
-	valueNullable Bool
-} representation map {
-	field valueNullable default "false"
-}
+	valueNullable Bool (implicit "false")
+} representation map
 
 ## TypeLink describes a hash linking to another object (a CID).
 ##
@@ -315,12 +311,9 @@ type TypeStruct struct {
 ##
 type StructField struct {
 	type TypeTerm
-	optional Bool
-	nullable Bool
-} representation map {
-	field optional default "false"
-	field nullable default "false"
-}
+	optional Bool (implicit "false")
+	nullable Bool (implicit "false")
+} representation map
 
 ## TypeTerm is a union of either TypeName or an InlineDefn. th It's used for the
 ## value type in the recursive types (maps, lists, and the fields of structs),


### PR DESCRIPTION
Schema update: use implicits; also, more docs.

- the "default" feature of representations has been renamed:
it is now known as "implicit".  We believe this better clarifies
what the feature does: the old name suggests that it might create
a surjective function; it is in fact a bijective function.
(Thanks to @merovius for the first suggestion of this new name!)

- several representation blocks removed: we've introduced the
ability to annotate fields in struct types with per-field
representation details inline, which shortens some things
significantly.  (The IPLD-native representation still keeps
representations clearly separated even at the cost of redundant keys.)

- new documentation file describing the above design.