### PR TITLE
Schema update: no more anon params to representation strategy.

### DIFF
--- a/schema-layer/schemas/schema-schema.ipldsch
+++ b/schema-layer/schemas/schema-schema.ipldsch
@@ -87,7 +87,9 @@ type Type union {
 	| TypeUnion "union"
 	| TypeStruct "struct"
 	| TypeEnum "enum"
-} representation inline "kind"
+} representation inline {
+	discriminantKey "kind"
+}
 
 ## TypeKind enumerates all the major kinds of type.
 ## Notice this enum's members are the same as the set of strings used as
@@ -356,7 +358,9 @@ type TypeTerm union {
 type InlineDefn union {
 	| TypeMap "map"
 	| TypeList "list"
-} representation inline "kind"
+} representation inline {
+	discriminantKey "kind"
+}
 
 ## StructRepresentation describes how a struct type should be mapped onto
 ## its IPLD Data Model representation.  Typically, maps are the representation


### PR DESCRIPTION
Previous syntax which allowed anonymous parameters to representation strategies dropped.  (This had appeared in the schema-schema in the uses of "inline" unions.)  Those parameters are now always named, and thus require the use of a full block to complete the representation description.  This is much more future-proof, and gives more indications about what is going on, as well as more words we can ascribe documentation to.

This change, like most of the others I'm making today, is prompted by multiple accumulated incidents of user feedback indicating that the earlier syntax was non-obvious and forced them to ask questions.