### PR TITLE
Schema update: remove obvious/redundant kind keywords in type declarations.

### DIFF
--- a/schema-layer/schemas/schema-schema.ipldsch
+++ b/schema-layer/schemas/schema-schema.ipldsch
@@ -29,7 +29,7 @@ type TypeName string
 ## }
 ## ```
 ##
-type SchemaMap map {TypeName:Type}
+type SchemaMap {TypeName:Type}
 
 ## Schema is a single-member union, which can be used in serialization
 ## to make a form of "nominative type declaration".
@@ -227,7 +227,7 @@ type UnionRepresentation union {
 ##
 ## The referenced type must of course produce the RepresentationKind it's
 ## matched with!
-type UnionRepresentation_Kinded map {RepresentationKind:TypeName}
+type UnionRepresentation_Kinded {RepresentationKind:TypeName}
 
 ## "Keyed" union representations will encode as a map, where the map has
 ## exactly one entry, the key string of which will be used to look up the name
@@ -237,7 +237,7 @@ type UnionRepresentation_Kinded map {RepresentationKind:TypeName}
 ## over the other styles wherever possible; keyed unions tend to have good
 ## performance characteristics, as they have most "mechanical sympathy" with
 ## parsing and deserialization implementation order.
-type UnionRepresentation_Keyed map {String:TypeName}
+type UnionRepresentation_Keyed {String:TypeName}
 
 ## "Envelope" union representations will encode as a map, where the map has
 ## exactly two entries: the two keys should be of the exact strings specified


### PR DESCRIPTION
Elide 'map' and 'list' keywords in top-level type declarations.

In all other positions (e.g. inline type declarations for struct
fields, nested maps, and nested lists), there's no kind keyword used:
the '{' and '[' characters in the typeterm are already enough to be
explicit about what's going on.  Historically, we've also added
a kind keyword when making top-level type declarations, even though
it's technically redundant.

I'm a bit tepid about this change.  However, many people have
commented that the 'map' and 'list' keywords in this position seem odd
and redundant.  I'm outvoted.

The original idea was that the form is always roughly
"`type $typeName $kind [$block...]`" -- and the "block" would be
present only in types that need more info (like structs).
But it's not much of a pivot to just switch the model to
"`type $typeName $typeDefn`" -- where there's not necessarily an
appearance of a kind keyword, and instead when we see words like
"struct" appear here, it's because it's part of the "typeDefn".

So.  Here's that take.