### PR TITLE
Tweak foundations intro: no callout to typesystems

### DIFF
--- a/FOUNDATIONS.md
+++ b/FOUNDATIONS.md
@@ -1,7 +1,7 @@
 # IPLD Foundational Principles
 
 This document outlines parts of IPLD that should and should not be changed to
-ensure the success of future improvements (especially type systems).
+ensure the success of future improvements and the continuity of direction.
 
 **Definitions**
 


### PR DESCRIPTION
It's true that type systems and schema tooling is important and we care a lot about it, but it doesn't quite need an explicit shout at the very top of the document -- we get into it later.  Replaced it with some comments about continuity instead -- part of the purpose of our 'foundations' document should be keeping us going in a particular direction and (eventually, finite!) scope in addition to guiding improvements :)

Extracted from https://github.com/ipld/specs/pull/148 and regards earlier review in https://github.com/ipld/specs/pull/146#discussion_r308708466 .