### PR TITLE
Tweak foundations definitions: path segments, etc.

### DIFF
--- a/FOUNDATIONS.md
+++ b/FOUNDATIONS.md
@@ -5,13 +5,16 @@ ensure the success of future improvements (especially type systems).
 
 **Definitions**
 
-* Block: A block is a chunk of an IPLD DAG, encoded in a format. Blocks have CIDs.
-* Node: A node is a *point* in an IPLD DAG (object, array, number, etc.).
+* Block: A block is a chunk of an IPLD DAG, encoded in a format.
+  Blocks have [CID](./block-layer/CID.md)s.
+* Node: A node is a *point* in an IPLD DAG (map, list, number, etc.).
   Many nodes can exist encoded inside one Block.
 * Link: A link is a kind of IPLD Node that points to another IPLD Node.
-* Path Segment: A path segment a piece of information that describes a move from
-  one Node to another Node (effectively, either a map key or a list index).
-  A path segment only describes movement of a single stride.
+  Links are what make IPLD data a DAG rather than only a tree.
+  Links are content-addressable -- see [CID](./block-layer/CID.md).
+* Path Segment: A path segment is a piece of information that describes a move
+  from one Node to a directly connected child Node.  (In other words, a
+  Path Segment is either a map key or a list index.)
 * Path: A path is composed of Path Segments, thereby describing a traversal
   from one Node to another Node somewhere deeper in the DAG.
 

--- a/FOUNDATIONS.md
+++ b/FOUNDATIONS.md
@@ -6,10 +6,14 @@ ensure the success of future improvements (especially type systems).
 **Definitions**
 
 * Block: A block is a chunk of an IPLD DAG, encoded in a format. Blocks have CIDs.
-* Fragment: A piece of an IPLD DAG. Blocks contain fragments.
 * Node: A node is a *point* in an IPLD DAG (object, array, number, etc.).
-* Link: A link is an IPLD Node that points to another IPLD Node.
-* Path: A paths a human readable pointer to an IPLD Node.
+  Many nodes can exist encoded inside one Block.
+* Link: A link is a kind of IPLD Node that points to another IPLD Node.
+* Path Segment: A path segment a piece of information that describes a move from
+  one Node to another Node (effectively, either a map key or a list index).
+  A path segment only describes movement of a single stride.
+* Path: A path is composed of Path Segments, thereby describing a traversal
+  from one Node to another Node somewhere deeper in the DAG.
 
 ## Linked
 


### PR DESCRIPTION
Dropped mention of "Fragments".  We don't seem to use that term much.  It's not a bad term; it just doesn't seem to have reached the frequency of usage which makes it seem important to include in the  glossary of most critical terms.

Inserted the word "kind" into the description of links.

Reworked "Path" to describe "Path" and "Path Segment" separately. This bit is a bit touchy to phrase well, and has already gone through some massaging in another PR; hopefully we're getting *closer*.

Extracts some content from #148, and regards earlier review in https://github.com/ipld/specs/pull/146#discussion_r308709312 , and also incorporates a bit of feedback from https://github.com/ipld/specs/pull/148/files/bea80f71e78fe97799526b1414931904010a397b#r309488666 .