### PR TITLE
HashMap: don't serialize `bitWidth`, infer it from `map` length

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ The Schema Layer will also serve as an enabling layer for complex multi-block da
 
 |     |      |
 |-----|------|
-| [Specification: IPLD Schemas](schemas/README.md) | [schemas/README.md](schemas/README.md) |
 | [Concept: IPLD Multi-block Collections](schema-layer/data-structures/multiblock-collections.md) | [schema-layer/data-structures/multiblock-collections.md](schema-layer/data-structures/multiblock-collections.md) |
+| [Specification: IPLD Schemas](schemas/README.md) | [schemas/README.md](schemas/README.md) |
+| [Specification: HashMap](schema-layer/data-structures/hashmap.md) | [schema-layer/data-structures/hashmap.md](schema-layer/data-structures/hashmap.md) |
 
 ## Specification document status
 


### PR DESCRIPTION
An outstanding item from https://github.com/ipld/specs/pull/131, I've implemented this, in JavaScript at least, and it's 👌.

Note that the minimum `bitWidth` of `3` is now a "must" not a "should" as less than that would give us a `map` length of less than 1-byte, breaking our ability to infer `bitWidth` from `map` length.