### PR TITLE
schemas: links & schemas, and the `&` hinting mechanism

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -11,6 +11,7 @@ Documentation:
 - [Schema Kinds](./schema-kinds.md)
 - [Representations](./representations.md)
 - [Schema DSL](./schema-dsl.md)
+- [Links and IPLD Schemas](./links.md)
 
 Examples:
 

--- a/schemas/links.md
+++ b/schemas/links.md
@@ -1,0 +1,85 @@
+Links and IPLD Schemas
+---------------------
+
+IPLD Schemas are designed to describe data bounded by blocks. They are intentionally _not_ agnostic to block boundaries to contain the complexity of validation. You ought to be able to apply a schema to a block and have enough information to make fast, complete, validation.
+
+The `link` kind may be used as with all other [data model kinds](./schema-kinds.md) in schemas. These define effective block boundaries. e.g.
+
+```ipldsch
+type Foo struct {
+  baz Int
+  boom Link
+}
+```
+
+Which tells us that there exists a `map` (the default `struct` representation) that contains a `baz` integer property and a `boom` link property. In this way we can state explicitly where to expect links in the same manner as describing the position of every other data model kind.
+
+Links may appear in `struct`s, as elements of `list`s and as values of `map`s. They may also appear in `union`s if they are also assigned to a type:
+
+```ipldsch
+type MyKeyedUnion union {
+  | Foo "foo"
+  | Bar "bar"
+} representation keyed
+
+type Foo struct { froz Bool }
+type Bar link
+```
+
+This works for and for `envelope` `union`s, and also `kinded` `union`s, as `link` is a kind that can be discriminated. `inline` `union`s, however, currently describe complex types (structs) so cannot directly describe `link`s, although the containing `struct`s may contain `link`s.
+
+## Link destination type hinting
+
+In many cases it is helpful to describe what is intended to occur across block boundaries, even though this cannot be verified by schemas in their per-block usage. For the purpose of codegen and as a documentation tool, we can provide "hinting" regarding the shape of the data (in schema terms) on the other side of a link.
+
+We use the **`&`** operator to convert a complex `type` into a link, where, for the purpose of in-block validation we expect the thing it describes to be a `link`, but for the purpose of cross-block traversal we can _suggest_ that what is on the other side of the `link` is of a particular `type`.
+
+In our original `struct` example, we could suggest that the `boom` property of `Foo`, when followed, will yield a `Grop`:
+
+```ipldsch
+type Foo struct {
+  baz Int
+  boom &Grop
+}
+
+type Grop struct {
+  description String
+  x Float
+  y Float
+  data [ Int ]
+}
+```
+
+For the purpose of validation this works for `Foo` in precisely the same way as our original example; we still expect `boom` to be a link, and such validation may be successful regardless of what might be found if the link were followed. But we are now providing a "hint" that we expect that when following the link at `boom` we should find an object that can be described by `Grop`.
+
+In the same way, our `keyed` `union` may be made more sophisticated to describe what we expect to be found if we were to follow the link:
+
+```ipldsch
+type MyKeyedUnion union {
+  | Foo "foo"
+  | &Grop "bar"
+} representation keyed
+
+type Foo struct { froz Bool }
+```
+
+There is no facility in IPLD Schemas for implicitly describing a "may be a link, or may be inline" data structure. However we can do this explicitly with `kinded` `union`s, although without strong guarantees regarding what we might find when we follow a link:
+
+```ipldsch
+type HashMapNode struct {
+  map Bytes
+  data [ Element ]
+}
+
+type Element union {
+  | HashMapNode map
+  | &HashMapNode link
+  | Bucket list
+} representation kinded
+
+# ... further definitions for `Bucket`
+```
+
+In this example, from the [HashMap](../schema-layer/data-structures/hashmap.md) spec, we describe a `map`, named `HashMapNode` that contains a `data` property which is a list of `Element`s. These `Element`s may be one of three things: a `map` that contains another `HashMapNode` (an inlined child for a tree data structure), a `link` which is assumed to lead to a `HashMapNode` (a linked child) or a `Bucket` (not described here) which comprises a `list`.
+
+Our validator can scan the `data` list and check that each element is one of: `map`, `link` and `list`. We make no strong assertions that the `link` actually yields a `HashMapNode` but such assertions may be built into code generated from this schema _when_ the link is loaded and validated.

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -178,11 +178,16 @@ type TypeList struct {
 } representation map
 
 ## TypeLink describes a hash linking to another object (a CID).
-##
-## REVIEW: this currently has no details... but possibly it should have a
-## type hint for what we expect when resolving the link?
-##
-type TypeLink struct {}
+## A link also has an "expectedType" that provides a hinting mechanism
+## suggesting what we should find if we were to follow the link. This
+## cannot be strictly enforced by a node or block-level schema
+## validation but may be enforced elsewhere in an application relying on
+## a schema.
+## The expectedType is specified with the `&Any` link shorthand, where
+## `Any` may be replaced with a specific type.
+type TypeLink struct {
+	expectedType TypeTerm (implicit "Any")
+}
 
 ## TypeUnion describes a union (sometimes called a "sum type", or
 ## more verbosely, a "discriminated union").

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -146,9 +146,19 @@
 		},
 		"TypeLink": {
 			"kind": "struct",
-			"fields": {},
+			"fields": {
+				"expectedType": {
+					"type": "TypeTerm"
+				}
+			},
 			"representation": {
-				"map": {}
+				"map": {
+					"fields": {
+						"expectedType": {
+							"implicit": "Any"
+						}
+					}
+				}
 			}
 		},
 		"TypeUnion": {


### PR DESCRIPTION
Some words about links and schemas to clear up some thinking on the topic.

Added the concept of a `&` hinting mechanism that has been floating around some of our discussions and I even used in the [HashMap](./schema-layer/data-structures/hashmap.md) spec schema. I don't have a proposal for this would be represented in the reified schema form but I could imagine a `"hints"` block in addition to the `"representation"` block, but I could also imagine this filling up with other things useful for codegen.

Discuss ..