### PR TITLE
schemas: define advanced layouts

### DIFF
--- a/design/history/exploration-reports/2019.09-adl-schema-root-type-defn.md
+++ b/design/history/exploration-reports/2019.09-adl-schema-root-type-defn.md
@@ -1,0 +1,89 @@
+Root type definitions for ADL schema declarations
+=================================================
+
+This text formed an original part of https://github.com/ipld/specs/pull/182 for the file schemas/advanced-layouts.md. The initial proposal included a `root` type specifier for `advanced` declarations that would allow the schema parser to make assumptions (and assertions) about the data found at the node where the ADL was encountered.
+
+This (partly) necessitated the connection of an ADL implementation schema to an ADL usage schema, such that a user would have to reach into the implementation and refer to a type defined there. For this reason (primarily), `root` was removed from the proposal and an ADL is to be declared simply with its name, `advanced Foo`, and no additional information, for now.
+
+---------------------------
+
+## Root node type definitions
+
+Advanced layouts are designed to abstract data that exists at the data model layer. As such, they may also dictate what they expect from the data that exists at the node their _root_ resides at.
+
+In the case of our `ROT13` `string` representation, we are likely to want to store this on the block as a `string` (i.e. this is a crude encryption mechanism, transforming `string` to `string`—realistic encryption mechanisms are likely to involve `bytes` and perhaps complex data structures to store encryption metadata).
+
+```ipldsch
+advanced ROT13 {
+  root String
+}
+
+type MyString string representation ROT13
+
+type Name struct {
+  firstname MyString
+  surname MyString
+}
+```
+
+A validator using our schema is now able to assert that it should find a `map` (default `struct` representation) with two fields, `firstname` and `surname`, and, thanks to the `root` definition of `ROT13`, it may also assert that these two fields are of kind `string`.
+
+We may also introduce complex types as the root definition. For example, a `byte` representation that is a chain of blocks, each containing a section of `bytes` and a link to the next block:
+
+```ipldsch
+advanced ChainedBytes {
+  root Chunk
+}
+
+type Chunk struct {
+  contents Bytes
+  next nullable Link
+}
+```
+
+Or, as in the IPLD [HashMap](../schema-layer/data-structures/hashmap.md) spec:
+
+```ipldsch
+advanced HashMap {
+  root HashMapRoot
+}
+
+# Root node layout
+type HashMapRoot struct {
+  hashAlg String
+  bucketSize Int
+  map Bytes
+  data [ Element ]
+}
+
+# ... `Element` (and further) definition omitted
+```
+
+And we could use this to define a map of `string`s to `link`s:
+
+```ipldsch
+type MyMap { String : Link } representation HashMap
+```
+
+We could even combine usage of our `ROT13` and `HashMap` definitions in novel ways:
+
+```ipldsch
+type BigConfidentialCatalog [ Secretz ]
+
+type Secretz struct {
+  title MyString
+  data MyMap
+}
+
+type MyMap { String : Name } representation HashMap
+```
+
+If we were to take an IPLD node, and assert that it is of type `BigConfidentialCatalog`, we should expect that:
+
+1. The node is a `list` kind
+2. Each element of the `list` contains a `map`, which is described by `Secretz`
+3. Each map contains the two properties defined by `Secretz`: `title` and `data`
+4. The `title` property of the `map` is of `string` kind, thanks to the `MyString` definition, but it must be transformed through the `ROT13` layout to make sense of it.
+5. The `data` property of the `map` is of `map` kind, which itself should conform to the `HashMapRoot` type specification, but must be interacted through with the logic associated with `HashMap` in order to make sense of it (which may also involve loading further blocks to traverse the sharded data).
+
+If `ROT13` and `HashMap` were to omit their `root` descriptor, we could only make assertions 1 and 2 above.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -12,6 +12,7 @@ Documentation:
 - [Representations](./representations.md)
 - [Schema DSL](./schema-dsl.md)
 - [Links and IPLD Schemas](./links.md)
+- [Advanced Layouts](./advanced-layouts.md)
 
 Examples:
 

--- a/schemas/advanced-layouts.md
+++ b/schemas/advanced-layouts.md
@@ -22,10 +22,10 @@ At its most basic, no properties are mandated for advanced layout. One may be de
 advanced ROT13
 ```
 
-It may then be used as a `representation` for a `type`, from which we can infer the `kind` that we expect.
+It may then be used as an `advanced` `representation` for a `type`, from which we can infer the `kind` that we expect.
 
 ```ipldsch
-type MyString string representation ROT13
+type MyString string representation advanced ROT13
 ```
 
 Similarly, an advanced layout implementing a sharded `map` may be defined and used as:
@@ -33,88 +33,7 @@ Similarly, an advanced layout implementing a sharded `map` may be defined and us
 ```ipldsch
 advanced ShardedMap
 
-type MyMap { String : Link } representation ShardedMap
+type MyMap { String : &Any } representation advanced ShardedMap
 ```
 
-From this usage, we may infer that `ShardedMap` can (1) present a familiar `map` kind interface and (2) store `link`s as values, referenced by standard data model `string`s. Other operating modes for `ShardedMap` may also be possible (it may be able to store other value kinds, or it may even be able to act as a `bytes` kind in spite of its name!).
-
-## Root node type definitions
-
-Advanced layouts are designed to abstract data that exists at the data model layer. As such, they may also dictate what they expect from the data that exists at the node their _root_ resides at.
-
-In the case of our `ROT13` `string` representation, we are likely to want to store this on the block as a `string` (i.e. this is a crude encryption mechanism, transforming `string` to `string`—realistic encryption mechanisms are likely to involve `bytes` and perhaps complex data structures to store encryption metadata).
-
-```ipldsch
-advanced ROT13 {
-  root String
-}
-
-type MyString string representation ROT13
-
-type Name struct {
-  firstname MyString
-  surname MyString
-}
-```
-
-A validator using our schema is now able to assert that it should find a `map` (default `struct` representation) with two fields, `firstname` and `surname`, and, thanks to the `root` definition of `ROT13`, it may also assert that these two fields are of kind `string`.
-
-We may also introduce complex types as the root definition. For example, a `byte` representation that is a chain of blocks, each containing a section of `bytes` and a link to the next block:
-
-```ipldsch
-advanced ChainedBytes {
-  root Chunk
-}
-
-type Chunk struct {
-  contents Bytes
-  next nullable Link
-}
-```
-
-Or, as in the IPLD [HashMap](../schema-layer/data-structures/hashmap.md) spec:
-
-```ipldsch
-advanced HashMap {
-  root HashMapRoot
-}
-
-# Root node layout
-type HashMapRoot struct {
-  hashAlg String
-  bucketSize Int
-  map Bytes
-  data [ Element ]
-}
-
-# ... `Element` (and further) definition omitted
-```
-
-And we could use this to define a map of `string`s to `link`s:
-
-```ipldsch
-type MyMap { String : Link } representation HashMap
-```
-
-We could even combine usage of our `ROT13` and `HashMap` definitions in novel ways:
-
-```ipldsch
-type BigConfidentialCatalog [ Secretz ]
-
-type Secretz struct {
-  title MyString
-  data MyMap
-}
-
-type MyMap { String : Name } representation HashMap
-```
-
-If we were to take an IPLD node, and assert that it is of type `BigConfidentialCatalog`, we should expect that:
-
-1. The node is a `list` kind
-2. Each element of the `list` contains a `map`, which is described by `Secretz`
-3. Each map contains the two properties defined by `Secretz`: `title` and `data`
-4. The `title` property of the `map` is of `string` kind, thanks to the `MyString` definition, but it must be transformed through the `ROT13` layout to make sense of it.
-5. The `data` property of the `map` is of `map` kind, which itself should conform to the `HashMapRoot` type specification, but must be interacted through with the logic associated with `HashMap` in order to make sense of it (which may also involve loading further blocks to traverse the sharded data).
-
-If `ROT13` and `HashMap` were to omit their `root` descriptor, we could only make assertions 1 and 2 above.
+From this usage, we may infer that `ShardedMap` can (1) present a familiar `map` kind interface and (2) store `link`s as values (with no specific "expectedType"), referenced by standard data model `string`s. Other operating modes for `ShardedMap` may also be possible (it may be able to store other value kinds, or it may even be able to act as a `bytes` kind in spite of its name!).

--- a/schemas/advanced-layouts.md
+++ b/schemas/advanced-layouts.md
@@ -1,0 +1,120 @@
+Advanced Layouts for IPLD Schemas
+---------------------------------
+
+An "advanced layout" is a special type in an IPLD Schema that denotes an abstract node that may _act_ as one of the standard IPLD [schema kinds](./schema-kinds.md) when interacted with above the schema layer, but be represented in entirely different data forms at the data model layer. Advanced layouts allow us to use transformational logic to present consistent interfaces to significantly more complex data than the data model otherwise allows or significantly larger data than reasonable block sizes allow.
+
+Data structures such as maps, lists or byte arrays may be implemented in novel forms with the data model and may even transparently cross block boundaries to present data that is potentially both larger and more complex than a standard data model kind while affording the standard data model API interaction modes of their respective kinds.
+
+Example uses of advanced layouts include:
+
+* Very large byte arrays that may cross many block boundaries but still present a standard `bytes` kind interface.
+* Maps that can be sharded across many blocks allowing efficient access via standard `map` kind interfaces while allowing extremely large storage.
+* Encrypted block mechanisms that are able to encode and decode data at the data model layer (perhaps in `byte` or `string` form) while presenting as unencrypted kinds when accessed through the schema layer.
+* Novel kind representation formats, such as high-precision or large numbers or alternative string encoding formats. Although size constraints at the language layer for number kinds may represent challenges for large or high-precision number formats.
+
+Advanced layouts necessarily involve a form of logic to perform their data transformations. Many use-cases even necessitate interaction with block loading and storing mechanisms, such as traversal of a large `bytes` array stored across a chain of blocks. There is currently no formal requirement for where this logic resides, how it is loaded, or how it is associated with an IPLD Schema definition. This topic will continue to evolve. There is potential in the future for such logic to be embedded _in_ IPLD blocks themselves via WebAssembly, such that an advanced layout is represented both by the data and the logic required to read it. See [#130](https://github.com/ipld/specs/issues/130) for an early exploration of some of these themes.
+
+## Basic schema definition and use
+
+At its most basic, no properties are mandated for advanced layout. One may be defined simply with the keyword `advanced` in a similar manner to `type`:
+
+```ipldsch
+advanced ROT13
+```
+
+It may then be used as a `representation` for a `type`, from which we can infer the `kind` that we expect.
+
+```ipldsch
+type MyString string representation ROT13
+```
+
+Similarly, an advanced layout implementing a sharded `map` may be defined and used as:
+
+```ipldsch
+advanced ShardedMap
+
+type MyMap { String : Link } representation ShardedMap
+```
+
+From this usage, we may infer that `ShardedMap` can (1) present a familiar `map` kind interface and (2) store `link`s as values, referenced by standard data model `string`s. Other operating modes for `ShardedMap` may also be possible (it may be able to store other value kinds, or it may even be able to act as a `bytes` kind in spite of its name!).
+
+## Root node type definitions
+
+Advanced layouts are designed to abstract data that exists at the data model layer. As such, they may also dictate what they expect from the data that exists at the node their _root_ resides at.
+
+In the case of our `ROT13` `string` representation, we are likely to want to store this on the block as a `string` (i.e. this is a crude encryption mechanism, transforming `string` to `string`—realistic encryption mechanisms are likely to involve `bytes` and perhaps complex data structures to store encryption metadata).
+
+```ipldsch
+advanced ROT13 {
+  root String
+}
+
+type MyString string representation ROT13
+
+type Name struct {
+  firstname MyString
+  surname MyString
+}
+```
+
+A validator using our schema is now able to assert that it should find a `map` (default `struct` representation) with two fields, `firstname` and `surname`, and, thanks to the `root` definition of `ROT13`, it may also assert that these two fields are of kind `string`.
+
+We may also introduce complex types as the root definition. For example, a `byte` representation that is a chain of blocks, each containing a section of `bytes` and a link to the next block:
+
+```ipldsch
+advanced ChainedBytes {
+  root Chunk
+}
+
+type Chunk struct {
+  contents Bytes
+  next nullable Link
+}
+```
+
+Or, as in the IPLD [HashMap](../schema-layer/data-structures/hashmap.md) spec:
+
+```ipldsch
+advanced HashMap {
+  root HashMapRoot
+}
+
+# Root node layout
+type HashMapRoot struct {
+  hashAlg String
+  bucketSize Int
+  map Bytes
+  data [ Element ]
+}
+
+# ... `Element` (and further) definition omitted
+```
+
+And we could use this to define a map of `string`s to `link`s:
+
+```ipldsch
+type MyMap { String : Link } representation HashMap
+```
+
+We could even combine usage of our `ROT13` and `HashMap` definitions in novel ways:
+
+```ipldsch
+type BigConfidentialCatalog [ Secretz ]
+
+type Secretz struct {
+  title MyString
+  data MyMap
+}
+
+type MyMap { String : Name } representation HashMap
+```
+
+If we were to take an IPLD node, and assert that it is of type `BigConfidentialCatalog`, we should expect that:
+
+1. The node is a `list` kind
+2. Each element of the `list` contains a `map`, which is described by `Secretz`
+3. Each map contains the two properties defined by `Secretz`: `title` and `data`
+4. The `title` property of the `map` is of `string` kind, thanks to the `MyString` definition, but it must be transformed through the `ROT13` layout to make sense of it.
+5. The `data` property of the `map` is of `map` kind, which itself should conform to the `HashMapRoot` type specification, but must be interacted through with the logic associated with `HashMap` in order to make sense of it (which may also involve loading further blocks to traverse the sharded data).
+
+If `ROT13` and `HashMap` were to omit their `root` descriptor, we could only make assertions 1 and 2 above.

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -179,10 +179,12 @@ type AnyScalar union {
 type AdvancedDataLayout struct {}
 
 ## TypeBool describes a simple boolean type.
+## It has no details.
 ##
 type TypeBool struct {}
 
 ## TypeString describes a simple string type.
+## It has no details.
 ##
 type TypeString struct {}
 
@@ -207,10 +209,12 @@ type BytesRepresentation union {
 type BytesRepresentation_Bytes struct {}
 
 ## TypeInt describes a simple integer numeric type.
+## It has no details.
 ##
 type TypeInt struct {}
 
 ## TypeFloat describes a simple floating point numeric type.
+## It has no details.
 ##
 type TypeFloat struct {}
 

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -36,6 +36,10 @@ type SchemaMap {TypeName:Type}
 ##
 ## The same constraints and conventions apply as for TypeName.
 ##
+## This identifier is used for keys in the AdvancedDataLayoutMap and also as
+## references to ADLs where the "advanced" representation strategy is used for
+## the types that support it.
+##
 type AdvancedDataLayoutName string
 
 ## AdvancedDataLayoutMap defines the set of ADLs found within the schema. It
@@ -174,18 +178,6 @@ type AnyScalar union {
 ##
 type AdvancedDataLayout struct {}
 
-## AdvancedRepresentation allows for "advanced" representations on all of
-## basic types. Currently it only requires a "name", which is supplied short-
-## hand after the `advanced` keyword
-##
-## (e.g. `type Foo string representation advanced Bar`) where "Bar" is the
-## name. This name should match an AdvancedDataLayoutName in the
-## "advanced" AdvancedDataLayoutMap map that exists elsewhere in the schema.
-##
-type AdvancedRepresentation struct {
-	name AdvancedDataLayoutName
-}
-
 ## TypeBool describes a simple boolean type.
 ##
 type TypeBool struct {}
@@ -206,7 +198,7 @@ type TypeBytes struct {
 ##
 type BytesRepresentation union {
 	| BytesRepresentation_Bytes "bytes"
-	| AdvancedRepresentation "advanced"
+	| AdvancedDataLayoutName "advanced"
 } representation keyed
 
 ## BytesRepresentation_Bytes is the default representation for TypeBytes and
@@ -240,7 +232,7 @@ type MapRepresentation union {
 	| MapRepresentation_Map "map"
 	| MapRepresentation_StringPairs "stringpairs"
 	| MapRepresentation_ListPairs "listpairs"
-	| AdvancedRepresentation "advanced"
+	| AdvancedDataLayoutName "advanced"
 } representation keyed
 
 ## MapRepresentation_Map describes that a map should be encoded as
@@ -296,7 +288,7 @@ type TypeList struct {
 ##
 type ListRepresentation union {
 	| ListRepresentation_List "list"
-	| AdvancedRepresentation "advanced"
+	| AdvancedDataLayoutName "advanced"
 } representation keyed
 
 ## ListRepresentation_List is the default representation for TypeList and

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -183,7 +183,7 @@ type AdvancedDataLayout struct {}
 ## "advanced" AdvancedDataLayoutMap map that exists elsewhere in the schema.
 ##
 type AdvancedRepresentation struct {
-	name String
+	name AdvancedDataLayoutName
 }
 
 ## TypeBool describes a simple boolean type.

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -32,6 +32,18 @@ type TypeName string
 ##
 type SchemaMap {TypeName:Type}
 
+## AdvancedDataLayoutName defines the name of an ADL as a string.
+##
+## The same constraints and conventions apply as for TypeName.
+##
+type AdvancedDataLayoutName string
+
+## AdvancedDataLayoutMap defines the set of ADLs found within the schema. It
+## maps the name (AdvancedDataLayoutName) to the AdvancedDataLayout, which is
+## currently an empty map.
+##
+type AdvancedDataLayoutMap {AdvancedDataLayoutName:AdvancedDataLayout}
+
 ## Schema is a single-member union, which can be used in serialization
 ## to make a form of "nominative type declaration".
 ##
@@ -47,9 +59,10 @@ type SchemaMap {TypeName:Type}
 ## }
 ## ```
 ##
-type Schema union {
-	| SchemaMap "schema"
-} representation keyed
+type Schema struct {
+	types SchemaMap
+	advanced AdvancedDataLayoutMap
+}
 
 ## The types of Type are a union.
 ##
@@ -148,27 +161,26 @@ type AnyScalar union {
 	| Float float
 } representation kinded
 
-## AdvancedDataLayout holds `advanced` definitions which currently only require
-## a name.
+## AdvancedDataLayout defines `advanced` definitions which are stored in the
+## top-level "advanced" map (AdvancedDataLayoutMap)
 ##
-## Use `advanced Foo` rather than `type Foo` to indicate an advanced data layout
-## (ADL) with that name which can be used as a representation for type
+## Used as `advanced Foo` rather than `type Foo` to indicate an advanced data
+## layout (ADL) with that name which can be used as a representation for type
 ## definitions whose kind the ADL is able to support.
 ##
-## The ADL name is currently the only identifier that can be used to make a
-## connection with the algorithm/logic behind this ADL. Future iterations may
-## formalize this connection by some other means.
+## The AdvancedDataLayoutName is currently the only identifier that can be used
+## to make a connection with the algorithm/logic behind this ADL. Future
+## iterations may formalize this connection by some other means.
 ##
-type AdvancedDataLayout struct {
-	name String
-}
+type AdvancedDataLayout struct {}
 
 ## AdvancedRepresentation allows for "advanced" representations on all of
 ## basic types. Currently it only requires a "name", which is supplied short-
 ## hand after the `advanced` keyword
+##
 ## (e.g. `type Foo string representation advanced Bar`) where "Bar" is the
-## name. This name should match an ADL definition that exists elsewhere in the
-## schema.
+## name. This name should match an AdvancedDataLayoutName in the
+## "advanced" AdvancedDataLayoutMap map that exists elsewhere in the schema.
 ##
 type AdvancedRepresentation struct {
 	name String
@@ -176,43 +188,11 @@ type AdvancedRepresentation struct {
 
 ## TypeBool describes a simple boolean type.
 ##
-type TypeBool struct {
-	representation BoolRepresentation
-}
-
-## BoolRepresentation specifies how a TypeBool is to be serialized. By default
-## it will be stored as a bool in the data model but it may be replaced with an
-## ADL.
-##
-type BoolRepresentation union {
-	| BoolRepresentation_Bool "bool"
-	| AdvancedRepresentation "advanced"
-} representation keyed
-
-## BoolRepresentation_Bool is the default representation for TypeBool and will
-## be used implicitly if no representation is specified.
-##
-type BoolRepresentation_Bool struct {}
+type TypeBool struct {}
 
 ## TypeString describes a simple string type.
 ##
-type TypeString struct {
-	representation StringRepresentation
-}
-
-## StringRepresentation specifies how a TypeString is to be serialized. By
-## default it will be stored as a string in the data model but it may be
-## replaced with an ADL.
-##
-type StringRepresentation union {
-	| StringRepresentation_String "string"
-	| AdvancedRepresentation "advanced"
-} representation keyed
-
-## StringRepresentation_String is the default representation for TypeString and
-## will be used implicitly if no representation is specified.
-##
-type StringRepresentation_String struct {}
+type TypeString struct {}
 
 ## TypeBytes describes a simple byte array type.
 ##
@@ -236,43 +216,11 @@ type BytesRepresentation_Bytes struct {}
 
 ## TypeInt describes a simple integer numeric type.
 ##
-type TypeInt struct {
-	representation IntRepresentation
-}
-
-## IntRepresentation specifies how a TypeInt is to be serialized. By
-## default it will be stored as an int in the data model but it may be replaced
-## with an ADL.
-##
-type IntRepresentation union {
-	| IntRepresentation_Int "int"
-	| AdvancedRepresentation "advanced"
-} representation keyed
-
-## IntRepresentation_Int is the default representation for TypeInt and
-## will be used implicitly if no representation is specified.
-##
-type IntRepresentation_Int struct {}
+type TypeInt struct {}
 
 ## TypeFloat describes a simple floating point numeric type.
 ##
-type TypeFloat struct {
-	representation FloatRepresentation
-}
-
-## FloatRepresentation specifies how a TypeFloat is to be serialized. By
-## default it will be stored as a float in the data model but it may be
-## replaced with an ADL.
-##
-type FloatRepresentation union {
-	| FloatRepresentation_Float "float"
-	| AdvancedRepresentation "advanced"
-} representation keyed
-
-## FloatRepresentation_Float is the default representation for TypeFloat and
-## will be used implicitly if no representation is specified.
-##
-type FloatRepresentation_Float struct {}
+type TypeFloat struct {}
 
 ## TypeMap describes a key-value map.
 ## The keys and values of the map have some specific type of their own.
@@ -376,22 +324,7 @@ type ListRepresentation_List struct {}
 ##
 type TypeLink struct {
 	expectedType String (implicit "Any")
-	representation LinkRepresentation
 }
-
-## LinkRepresentation specifies how a TypeLink is to be serialized. By
-## default it will be stored as a data model link (CID) but it may be
-## replaced with an ADL that performs the same role.
-##
-type LinkRepresentation union {
-	| LinkRepresentation_Link "link"
-	| AdvancedRepresentation "advanced"
-} representation keyed
-
-## LinkRepresentation_Link is the default representation for TypeLink and
-## will be used implicitly if no representation is specified.
-##
-type LinkRepresentation_Link struct {}
 
 ## TypeUnion describes a union (sometimes called a "sum type", or
 ## more verbosely, a "discriminated union").
@@ -426,7 +359,6 @@ type UnionRepresentation union {
 	| UnionRepresentation_Keyed "keyed"
 	| UnionRepresentation_Envelope "envelope"
 	| UnionRepresentation_Inline "inline"
-	| AdvancedRepresentation "advanced"
 } representation keyed
 
 ## "Kinded" union representations describe a bidirectional mapping between
@@ -590,7 +522,6 @@ type StructRepresentation union {
 	| StructRepresentation_StringPairs "stringpairs"
 	| StructRepresentation_StringJoin "stringjoin"
 	| StructRepresentation_ListPairs "listpairs"
-	| AdvancedRepresentation "advanced"
 } representation keyed
 
 ## StructRepresentation_Map describes a way to map a struct type onto a map
@@ -695,19 +626,4 @@ type StructRepresentation_ListPairs struct {}
 ##
 type TypeEnum struct {
 	members {String:Null}
-	representation EnumRepresentation
 }
-
-## EnumRepresentation specifies how a TypeEnum is to be serialized. By default
-## it will be stored as a string in the data model but it may be replaced with
-## an ADL.
-##
-type EnumRepresentation union {
-	| EnumRepresentation_String "string"
-	| AdvancedRepresentation "advanced"
-} representation keyed
-
-## EnumRepresentation_String is the default representation for TypeEnum and
-## will be used implicitly if no representation is specified.
-##
-type EnumRepresentation_String struct {}

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -148,30 +148,131 @@ type AnyScalar union {
 	| Float float
 } representation kinded
 
-## TypeBool describes a simple boolean type.
-## It has no details.
+## AdvancedDataLayout holds `advanced` definitions which currently only require
+## a name.
 ##
-type TypeBool struct {}
+## Use `advanced Foo` rather than `type Foo` to indicate an advanced data layout
+## (ADL) with that name which can be used as a representation for type
+## definitions whose kind the ADL is able to support.
+##
+## The ADL name is currently the only identifier that can be used to make a
+## connection with the algorithm/logic behind this ADL. Future iterations may
+## formalize this connection by some other means.
+##
+type AdvancedDataLayout struct {
+	name String
+}
+
+## AdvancedRepresentation allows for "advanced" representations on all of
+## basic types. Currently it only requires a "name", which is supplied short-
+## hand after the `advanced` keyword
+## (e.g. `type Foo string representation advanced Bar`) where "Bar" is the
+## name. This name should match an ADL definition that exists elsewhere in the
+## schema.
+##
+type AdvancedRepresentation struct {
+	name String
+}
+
+## TypeBool describes a simple boolean type.
+##
+type TypeBool struct {
+	representation BoolRepresentation
+}
+
+## BoolRepresentation specifies how a TypeBool is to be serialized. By default
+## it will be stored as a bool in the data model but it may be replaced with an
+## ADL.
+##
+type BoolRepresentation union {
+	| BoolRepresentation_Bool "bool"
+	| AdvancedRepresentation "advanced"
+} representation keyed
+
+## BoolRepresentation_Bool is the default representation for TypeBool and will
+## be used implicitly if no representation is specified.
+##
+type BoolRepresentation_Bool struct {}
 
 ## TypeString describes a simple string type.
-## It has no details.
 ##
-type TypeString struct {}
+type TypeString struct {
+	representation StringRepresentation
+}
+
+## StringRepresentation specifies how a TypeString is to be serialized. By
+## default it will be stored as a string in the data model but it may be
+## replaced with an ADL.
+##
+type StringRepresentation union {
+	| StringRepresentation_String "string"
+	| AdvancedRepresentation "advanced"
+} representation keyed
+
+## StringRepresentation_String is the default representation for TypeString and
+## will be used implicitly if no representation is specified.
+##
+type StringRepresentation_String struct {}
 
 ## TypeBytes describes a simple byte array type.
-## It has no details.
 ##
-type TypeBytes struct {}
+type TypeBytes struct {
+	representation BytesRepresentation
+}
+
+## BytesRepresentation specifies how a TypeBytes is to be serialized. By
+## default it will be stored as bytes in the data model but it may be replaced
+## with an ADL.
+##
+type BytesRepresentation union {
+	| BytesRepresentation_Bytes "bytes"
+	| AdvancedRepresentation "advanced"
+} representation keyed
+
+## BytesRepresentation_Bytes is the default representation for TypeBytes and
+## will be used implicitly if no representation is specified.
+##
+type BytesRepresentation_Bytes struct {}
 
 ## TypeInt describes a simple integer numeric type.
-## It has no details.
 ##
-type TypeInt struct {}
+type TypeInt struct {
+	representation IntRepresentation
+}
+
+## IntRepresentation specifies how a TypeInt is to be serialized. By
+## default it will be stored as an int in the data model but it may be replaced
+## with an ADL.
+##
+type IntRepresentation union {
+	| IntRepresentation_Int "int"
+	| AdvancedRepresentation "advanced"
+} representation keyed
+
+## IntRepresentation_Int is the default representation for TypeInt and
+## will be used implicitly if no representation is specified.
+##
+type IntRepresentation_Int struct {}
 
 ## TypeFloat describes a simple floating point numeric type.
-## It has no details.
 ##
-type TypeFloat struct {}
+type TypeFloat struct {
+	representation FloatRepresentation
+}
+
+## FloatRepresentation specifies how a TypeFloat is to be serialized. By
+## default it will be stored as a float in the data model but it may be
+## replaced with an ADL.
+##
+type FloatRepresentation union {
+	| FloatRepresentation_Float "float"
+	| AdvancedRepresentation "advanced"
+} representation keyed
+
+## FloatRepresentation_Float is the default representation for TypeFloat and
+## will be used implicitly if no representation is specified.
+##
+type FloatRepresentation_Float struct {}
 
 ## TypeMap describes a key-value map.
 ## The keys and values of the map have some specific type of their own.
@@ -191,6 +292,7 @@ type MapRepresentation union {
 	| MapRepresentation_Map "map"
 	| MapRepresentation_StringPairs "stringpairs"
 	| MapRepresentation_ListPairs "listpairs"
+	| AdvancedRepresentation "advanced"
 } representation keyed
 
 ## MapRepresentation_Map describes that a map should be encoded as
@@ -237,7 +339,22 @@ type MapRepresentation_ListPairs struct {}
 type TypeList struct {
 	valueType TypeTerm
 	valueNullable Bool (implicit "false")
+	representation ListRepresentation
 } representation map
+
+## ListRepresentation describes how a map type should be mapped onto
+## its IPLD Data Model representation.  By default a list is a list in the
+## data model but it may be replaced with an ADL.
+##
+type ListRepresentation union {
+	| ListRepresentation_List "list"
+	| AdvancedRepresentation "advanced"
+} representation keyed
+
+## ListRepresentation_List is the default representation for TypeList and
+## will be used implicitly if no representation is specified.
+##
+type ListRepresentation_List struct {}
 
 ## TypeLink describes a hash linking to another object (a CID).
 ##
@@ -259,7 +376,22 @@ type TypeList struct {
 ##
 type TypeLink struct {
 	expectedType String (implicit "Any")
+	representation LinkRepresentation
 }
+
+## LinkRepresentation specifies how a TypeLink is to be serialized. By
+## default it will be stored as a data model link (CID) but it may be
+## replaced with an ADL that performs the same role.
+##
+type LinkRepresentation union {
+	| LinkRepresentation_Link "link"
+	| AdvancedRepresentation "advanced"
+} representation keyed
+
+## LinkRepresentation_Link is the default representation for TypeLink and
+## will be used implicitly if no representation is specified.
+##
+type LinkRepresentation_Link struct {}
 
 ## TypeUnion describes a union (sometimes called a "sum type", or
 ## more verbosely, a "discriminated union").
@@ -294,6 +426,7 @@ type UnionRepresentation union {
 	| UnionRepresentation_Keyed "keyed"
 	| UnionRepresentation_Envelope "envelope"
 	| UnionRepresentation_Inline "inline"
+	| AdvancedRepresentation "advanced"
 } representation keyed
 
 ## "Kinded" union representations describe a bidirectional mapping between
@@ -457,6 +590,7 @@ type StructRepresentation union {
 	| StructRepresentation_StringPairs "stringpairs"
 	| StructRepresentation_StringJoin "stringjoin"
 	| StructRepresentation_ListPairs "listpairs"
+	| AdvancedRepresentation "advanced"
 } representation keyed
 
 ## StructRepresentation_Map describes a way to map a struct type onto a map
@@ -561,4 +695,19 @@ type StructRepresentation_ListPairs struct {}
 ##
 type TypeEnum struct {
 	members {String:Null}
+	representation EnumRepresentation
 }
+
+## EnumRepresentation specifies how a TypeEnum is to be serialized. By default
+## it will be stored as a string in the data model but it may be replaced with
+## an ADL.
+##
+type EnumRepresentation union {
+	| EnumRepresentation_String "string"
+	| AdvancedRepresentation "advanced"
+} representation keyed
+
+## EnumRepresentation_String is the default representation for TypeEnum and
+## will be used implicitly if no representation is specified.
+##
+type EnumRepresentation_String struct {}

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -103,7 +103,7 @@
 			"kind": "struct",
 			"fields": {
 				"name": {
-					"type": "String"
+					"type": "AdvancedDataLayoutName"
 				}
 			},
 			"representation": {

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -78,7 +78,49 @@
 				}
 			}
 		},
+		"AdvancedDataLayout": {
+			"kind": "struct",
+			"fields": {
+				"name": {
+					"type": "String"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"AdvancedRepresentation": {
+			"kind": "struct",
+			"fields": {
+				"name": {
+					"type": "String"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
 		"TypeBool": {
+			"kind": "struct",
+			"fields": {
+				"representation": {
+					"type": "BoolRepresentation"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"BoolRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"bool": "BoolRepresentation_Bool",
+					"advanced": "AdvancedRepresentation"
+				}
+			}
+		},
+		"BoolRepresentation_Bool": {
 			"kind": "struct",
 			"fields": {},
 			"representation": {
@@ -87,12 +129,52 @@
 		},
 		"TypeString": {
 			"kind": "struct",
+			"fields": {
+				"representation": {
+					"type": "StringRepresentation"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StringRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"string": "StringRepresentation_String",
+					"advanced": "AdvancedRepresentation"
+				}
+			}
+		},
+		"StringRepresentation_String": {
+			"kind": "struct",
 			"fields": {},
 			"representation": {
 				"map": {}
 			}
 		},
 		"TypeBytes": {
+			"kind": "struct",
+			"fields": {
+				"representation": {
+					"type": "BytesRepresentation"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"BytesRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"bytes": "BytesRepresentation_Bytes",
+					"advanced": "AdvancedRepresentation"
+				}
+			}
+		},
+		"BytesRepresentation_Bytes": {
 			"kind": "struct",
 			"fields": {},
 			"representation": {
@@ -101,12 +183,52 @@
 		},
 		"TypeInt": {
 			"kind": "struct",
+			"fields": {
+				"representation": {
+					"type": "IntRepresentation"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"IntRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"int": "IntRepresentation_Int",
+					"advanced": "AdvancedRepresentation"
+				}
+			}
+		},
+		"IntRepresentation_Int": {
+			"kind": "struct",
 			"fields": {},
 			"representation": {
 				"map": {}
 			}
 		},
 		"TypeFloat": {
+			"kind": "struct",
+			"fields": {
+				"representation": {
+					"type": "FloatRepresentation"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"FloatRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"float": "FloatRepresentation_Float",
+					"advanced": "AdvancedRepresentation"
+				}
+			}
+		},
+		"FloatRepresentation_Float": {
 			"kind": "struct",
 			"fields": {},
 			"representation": {
@@ -145,7 +267,8 @@
 				"keyed": {
 					"map": "MapRepresentation_Map",
 					"stringpairs": "MapRepresentation_StringPairs",
-					"listpairs": "MapRepresentation_ListPairs"
+					"listpairs": "MapRepresentation_ListPairs",
+					"advanced": "AdvancedRepresentation"
 				}
 			}
 		},
@@ -185,6 +308,9 @@
 				},
 				"valueNullable": {
 					"type": "Bool"
+				},
+				"representation": {
+					"type": "ListRepresentation"
 				}
 			},
 			"representation": {
@@ -197,11 +323,30 @@
 				}
 			}
 		},
+		"ListRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"list": "ListRepresentation_List",
+					"advanced": "AdvancedRepresentation"
+				}
+			}
+		},
+		"ListRepresentation_List": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
 		"TypeLink": {
 			"kind": "struct",
 			"fields": {
 				"expectedType": {
 					"type": "String"
+				},
+				"representation": {
+					"type": "LinkRepresentation"
 				}
 			},
 			"representation": {
@@ -212,6 +357,22 @@
 						}
 					}
 				}
+			}
+		},
+		"LinkRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"link": "LinkRepresentation_Link",
+					"advanced": "AdvancedRepresentation"
+				}
+			}
+		},
+		"LinkRepresentation_Link": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
 			}
 		},
 		"TypeUnion": {
@@ -232,7 +393,8 @@
 					"kinded": "UnionRepresentation_Kinded",
 					"keyed": "UnionRepresentation_Keyed",
 					"envelope": "UnionRepresentation_Envelope",
-					"inline": "UnionRepresentation_Inline"
+					"inline": "UnionRepresentation_Inline",
+					"advanced": "AdvancedRepresentation"
 				}
 			}
 		},
@@ -361,7 +523,8 @@
 					"tuple": "StructRepresentation_Tuple",
 					"stringpairs": "StructRepresentation_StringPairs",
 					"stringjoin": "StructRepresentation_StringJoin",
-					"listpairs": "StructRepresentation_ListPairs"
+					"listpairs": "StructRepresentation_ListPairs",
+					"advanced": "AdvancedRepresentation"
 				}
 			}
 		},
@@ -460,8 +623,27 @@
 						"keyType": "String",
 						"valueType": "Null"
 					}
+				},
+				"representation": {
+					"type": "EnumRepresentation"
 				}
 			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"EnumRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"string": "EnumRepresentation_String",
+					"advanced": "AdvancedRepresentation"
+				}
+			}
+		},
+		"EnumRepresentation_String": {
+			"kind": "struct",
+			"fields": {},
 			"representation": {
 				"map": {}
 			}

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -99,17 +99,6 @@
 				"map": {}
 			}
 		},
-		"AdvancedRepresentation": {
-			"kind": "struct",
-			"fields": {
-				"name": {
-					"type": "AdvancedDataLayoutName"
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
 		"TypeBool": {
 			"kind": "struct",
 			"fields": {},
@@ -140,7 +129,7 @@
 			"representation": {
 				"keyed": {
 					"bytes": "BytesRepresentation_Bytes",
-					"advanced": "AdvancedRepresentation"
+					"advanced": "AdvancedDataLayoutName"
 				}
 			}
 		},
@@ -198,7 +187,7 @@
 					"map": "MapRepresentation_Map",
 					"stringpairs": "MapRepresentation_StringPairs",
 					"listpairs": "MapRepresentation_ListPairs",
-					"advanced": "AdvancedRepresentation"
+					"advanced": "AdvancedDataLayoutName"
 				}
 			}
 		},
@@ -258,7 +247,7 @@
 			"representation": {
 				"keyed": {
 					"list": "ListRepresentation_List",
-					"advanced": "AdvancedRepresentation"
+					"advanced": "AdvancedDataLayoutName"
 				}
 			}
 		},

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -1,5 +1,5 @@
 {
-	"schema": {
+	"types": {
 		"TypeName": {
 			"kind": "string"
 		},
@@ -8,12 +8,26 @@
 			"keyType": "TypeName",
 			"valueType": "Type"
 		},
+		"AdvancedDataLayoutName": {
+			"kind": "string"
+		},
+		"AdvancedDataLayoutMap": {
+			"kind": "map",
+			"keyType": "AdvancedDataLayoutName",
+			"valueType": "AdvancedDataLayout"
+		},
 		"Schema": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"schema": "SchemaMap"
+			"kind": "struct",
+			"fields": {
+				"types": {
+					"type": "SchemaMap"
+				},
+				"advanced": {
+					"type": "AdvancedDataLayoutMap"
 				}
+			},
+			"representation": {
+				"map": {}
 			}
 		},
 		"Type": {
@@ -80,11 +94,7 @@
 		},
 		"AdvancedDataLayout": {
 			"kind": "struct",
-			"fields": {
-				"name": {
-					"type": "String"
-				}
-			},
+			"fields": {},
 			"representation": {
 				"map": {}
 			}
@@ -102,52 +112,12 @@
 		},
 		"TypeBool": {
 			"kind": "struct",
-			"fields": {
-				"representation": {
-					"type": "BoolRepresentation"
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"BoolRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"bool": "BoolRepresentation_Bool",
-					"advanced": "AdvancedRepresentation"
-				}
-			}
-		},
-		"BoolRepresentation_Bool": {
-			"kind": "struct",
 			"fields": {},
 			"representation": {
 				"map": {}
 			}
 		},
 		"TypeString": {
-			"kind": "struct",
-			"fields": {
-				"representation": {
-					"type": "StringRepresentation"
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StringRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"string": "StringRepresentation_String",
-					"advanced": "AdvancedRepresentation"
-				}
-			}
-		},
-		"StringRepresentation_String": {
 			"kind": "struct",
 			"fields": {},
 			"representation": {
@@ -183,52 +153,12 @@
 		},
 		"TypeInt": {
 			"kind": "struct",
-			"fields": {
-				"representation": {
-					"type": "IntRepresentation"
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"IntRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"int": "IntRepresentation_Int",
-					"advanced": "AdvancedRepresentation"
-				}
-			}
-		},
-		"IntRepresentation_Int": {
-			"kind": "struct",
 			"fields": {},
 			"representation": {
 				"map": {}
 			}
 		},
 		"TypeFloat": {
-			"kind": "struct",
-			"fields": {
-				"representation": {
-					"type": "FloatRepresentation"
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"FloatRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"float": "FloatRepresentation_Float",
-					"advanced": "AdvancedRepresentation"
-				}
-			}
-		},
-		"FloatRepresentation_Float": {
 			"kind": "struct",
 			"fields": {},
 			"representation": {
@@ -344,9 +274,6 @@
 			"fields": {
 				"expectedType": {
 					"type": "String"
-				},
-				"representation": {
-					"type": "LinkRepresentation"
 				}
 			},
 			"representation": {
@@ -357,22 +284,6 @@
 						}
 					}
 				}
-			}
-		},
-		"LinkRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"link": "LinkRepresentation_Link",
-					"advanced": "AdvancedRepresentation"
-				}
-			}
-		},
-		"LinkRepresentation_Link": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
 			}
 		},
 		"TypeUnion": {
@@ -393,8 +304,7 @@
 					"kinded": "UnionRepresentation_Kinded",
 					"keyed": "UnionRepresentation_Keyed",
 					"envelope": "UnionRepresentation_Envelope",
-					"inline": "UnionRepresentation_Inline",
-					"advanced": "AdvancedRepresentation"
+					"inline": "UnionRepresentation_Inline"
 				}
 			}
 		},
@@ -523,8 +433,7 @@
 					"tuple": "StructRepresentation_Tuple",
 					"stringpairs": "StructRepresentation_StringPairs",
 					"stringjoin": "StructRepresentation_StringJoin",
-					"listpairs": "StructRepresentation_ListPairs",
-					"advanced": "AdvancedRepresentation"
+					"listpairs": "StructRepresentation_ListPairs"
 				}
 			}
 		},
@@ -623,27 +532,8 @@
 						"keyType": "String",
 						"valueType": "Null"
 					}
-				},
-				"representation": {
-					"type": "EnumRepresentation"
 				}
 			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"EnumRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"string": "EnumRepresentation_String",
-					"advanced": "AdvancedRepresentation"
-				}
-			}
-		},
-		"EnumRepresentation_String": {
-			"kind": "struct",
-			"fields": {},
 			"representation": {
 				"map": {}
 			}


### PR DESCRIPTION
Biting the bullet and coming up with a formal realisation of what "advanced layouts" might mean in terms of schema DSL.

I've opted to overload `representation` here, rather than the alternative genetics style syntax of `<Foo>`, I think it fits better but of course am happy to discuss, along with everything else in here! I know we all have slightly different things in our head for this stuff but we need to get some basics laid out at least.

Will follow up with an additional idea for parameterisation that goes a bit too far beyond this most basic level and is likely to be in discussion-limbo for much longer. I don't want to pollute this one with too many additional ideas that might hold it up.