### PR TITLE
schemas: complete map and struct representations for schema-schema

### DIFF
--- a/schemas/representations.md
+++ b/schemas/representations.md
@@ -111,7 +111,7 @@ serialized data incomprehensible without the schema information in hand.
 type Foo struct {
 	fieldOne String
 	fieldTwo Bool
-} representation tuiple
+} representation tuple
 ```
 
 Some data matching the `Foo` struct (shown as JSON) is:

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -177,8 +177,8 @@ type TypeMap struct {
 ##
 type MapRepresentation union {
 	| MapRepresentation_Map "map"
-	| Representation_StringPairs "stringpairs"
-	| Representation_ListPairs "listpairs"
+	| MapRepresentation_StringPairs "stringpairs"
+	| MapRepresentation_ListPairs "listpairs"
 } representation keyed
 
 ## MapRepresentation_Map describes that a map should be encoded as
@@ -186,8 +186,8 @@ type MapRepresentation union {
 ##
 type MapRepresentation_Map struct {}
 
-## Representation_StringPairs describes that a map, or struct, should
-## be encoded as a string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
+## MapRepresentation_StringPairs describes that a map should be encoded as a
+## string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
 ## The separating delimiter may be specified with "entryDelim", and the k/v
 ## delimiter may be specified with "innerDelim". So a "k=v" naive
 ## comma-separated form would use an "innerDelim" of "=" and an "entryDelim"
@@ -197,28 +197,27 @@ type MapRepresentation_Map struct {}
 ## exclude the "innerDelim" and values and keys must exclude ",".
 ## There is no facility for escaping, such as in escaped CSV.
 ## This also leads to a further restriction that this representation is only
-## valid for maps and structs whose keys and values may all be encoded to string
-## form without conflicts in delimiter character. It is recommended, therefore,
-## that its use be limited to structs containing values with the basic data
+## valid for maps whose keys and values may all be encoded to string form
+## without conflicts in delimiter character. It is recommended, therefore,
+## that its use be limited to maps containing values with the basic data
 ## model kinds that exclude multiple values (i.e. no maps, lists, and therefore
 ## structs or unions).
 ##
-type Representation_StringPairs struct {
+type MapRepresentation_StringPairs struct {
 	innerDelim String
 	entryDelim String
 }
 
-## Representation_ListPairs describes that a map, or struct, should
-## be encoded as a as a list in the IPLD Data Model. This list comprises
-## a sub-list for each entry, in the form: [[k1,v1],[k2,v2]].
+## MapRepresentation_ListPairs describes that a map should be encoded as a
+## list in the IPLD Data Model. This list comprises a sub-list for each entry,
+## in the form: [[k1,v1],[k2,v2]].
 ##
 ## This representation type is similar to StructRepresentation_Tuple except
-## it includes the keys. In the case of maps, this is critical since the
-## keys are not defined in the schema (hence "tuple" representation isn't
-## available for maps), but is optional for structs since they are. A tuple
-## representation for a struct will encode more compact than listpairs.
+## it includes the keys. This is critical for maps since the keys are not
+## defined in the schema (hence "tuple" representation isn't available for
+## maps).
 ##
-type Representation_ListPairs struct {}
+type MapRepresentation_ListPairs struct {}
 
 ## TypeList describes a list.
 ## The values of the list have some specific type of their own.
@@ -433,9 +432,9 @@ type InlineDefn union {
 type StructRepresentation union {
 	| StructRepresentation_Map "map"
 	| StructRepresentation_Tuple "tuple"
-	| Representation_StringPairs "stringpairs"
+	| StructRepresentation_StringPairs "stringpairs"
 	| StructRepresentation_StringJoin "stringjoin"
-	| Representation_listpairs "listpairs"
+	| StructRepresentation_ListPairs "listpairs"
 } representation keyed
 
 ## StructRepresentation_Map describes a way to map a struct type onto a map
@@ -483,8 +482,28 @@ type StructRepresentation_Map_FieldDetails struct {
 ## Tuple representations are less flexible than map representations:
 ## field order can be specified in order to override the order defined
 ## in the type, but optionals and implicits are not (currently) supported.
+## A `fieldOrder` list must include quoted strings (FieldName is a string
+## type) which are coerced to the names of the struct fields. e.g.:
+##   fieldOrder ["Foo", "Bar", "Baz"]
+##
 type StructRepresentation_Tuple struct {
 	fieldOrder optional [FieldName]
+}
+
+## StructRepresentation_StringPairs describes that a struct should be encoded
+## as a string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
+## The separating delimiter may be specified with "entryDelim", and the k/v
+## delimiter may be specified with "innerDelim". So a "k=v" naive
+## comma-separated form would use an "innerDelim" of "=" and an "entryDelim"
+## of ",".
+##
+## Serialization a struct with stringpairs works the same way as serializing
+## a map with stringpairs and the same character limitations exist. See
+## MapRepresentation_StringPairs for more details on these limitations.
+##
+type StructRepresentation_StringPairs struct {
+	innerDelim String
+	entryDelim String
 }
 
 ## StructRepresentation_StringJoin describes a way to encode a struct to
@@ -504,8 +523,20 @@ type StructRepresentation_StringJoin struct {
 	fieldOrder optional [FieldName]
 }
 
+## StructRepresentation_ListPairs describes that a struct, should be encoded as
+## a list in the IPLD Data Model. This list comprises a sub-list for each
+## entry, in the form: [[k1,v1],[k2,v2]].
+##
+## This representation type encodes in the same way as
+## MapStructRepresentation_Tuple. It is also similar to
+## StructRepresentation_Tuple except it includes the keys in nested lists.
+## A tuple representation for a struct will encode more compact than listpairs.
+##
+type StructRepresentation_ListPairs struct {}
+
 ## TypeEnum describes a type which has a known, pre-defined set of possible
 ## values.  Each of the values must be representable a string.
+##
 type TypeEnum struct {
 	members {String:Null}
 }

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -8,7 +8,8 @@
 ## There are some additional rules that should be applied:
 ##   - Type names should by convention begin with a capital letter;
 ##   - Type names must be all printable characters (no whitespace);
-##   - Type names must not contain punctuation (dashes, dots, etc).
+##   - Type names must not contain punctuation other than underscores
+##     (dashes, dots, etc.).
 ##
 ## Type names are strings meant for human consumption at a local scope.
 ## When making a Schema, note that the TypeName is the key of the map:
@@ -335,9 +336,23 @@ type UnionRepresentation_Inline struct {
 ## also exist).
 ##
 type TypeStruct struct {
-	fields {String:StructField}
+	fields {FieldName:StructField}
 	representation StructRepresentation
 }
+
+## FieldName is an alias of string.
+##
+## There are some additional rules that should be applied:
+##   - Field names should by convention begin with a lower-case letter;
+##   - Field names must be all printable characters (no whitespace);
+##   - Field names must not contain punctuation other than underscores
+##     (dashes, dots, etc.).
+##
+## Field names are strings meant for human consumption at a local scope.
+## When making a Schema, note that the FieldName is the key of the map:
+## a FieldName must be unique within the Schema.
+##
+type FieldName string
 
 ## StructField describes the properties of each field declared by a TypeStruct.
 ##
@@ -433,7 +448,7 @@ type StructRepresentation union {
 ## 'implicit' options.
 ##
 type StructRepresentation_Map struct {
-	fields optional {String:StructRepresentation_Map_FieldDetails}
+	fields optional {FieldName:StructRepresentation_Map_FieldDetails}
 }
 
 ## StructRepresentation_Map_FieldDetails describes additional properties of a
@@ -469,7 +484,7 @@ type StructRepresentation_Map_FieldDetails struct {
 ## field order can be specified in order to override the order defined
 ## in the type, but optionals and implicits are not (currently) supported.
 type StructRepresentation_Tuple struct {
-	fieldOrder optional [String]
+	fieldOrder optional [FieldName]
 }
 
 ## StructRepresentation_StringJoin describes a way to encode a struct to
@@ -486,7 +501,7 @@ type StructRepresentation_Tuple struct {
 ##
 type StructRepresentation_StringJoin struct {
 	join String
-	fieldOrder optional [String]
+	fieldOrder optional [FieldName]
 }
 
 ## TypeEnum describes a type which has a known, pre-defined set of possible

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -167,7 +167,57 @@ type TypeMap struct {
 	keyType TypeName # additionally, the referenced type must be reprkind==string.
 	valueType TypeTerm
 	valueNullable Bool (implicit "false")
+	representation MapRepresentation
 } representation map
+
+## MapRepresentation describes how a map type should be mapped onto
+## its IPLD Data Model representation.  By default a map is a map in the
+## Data Model but other kinds can be configured.
+##
+type MapRepresentation union {
+	| MapRepresentation_Map "map"
+	| Representation_StringPairs "stringpairs"
+	| Representation_ListPairs "listpairs"
+} representation keyed
+
+## MapRepresentation_Map describes that a map should be encoded as
+## a map in the Data Model
+##
+type MapRepresentation_Map struct {}
+
+## Representation_StringPairs describes that a map, or struct, should
+## be encoded as a string of delimited "k/v" entries, e.g. "k1=v1,k2=v2".
+## The separating delimiter may be specified with "entryDelim", and the k/v
+## delimiter may be specified with "innerDelim". So a "k=v" naive
+## comma-separated form would use an "innerDelim" of "=" and an "entryDelim"
+## of ",".
+##
+## This serial representation is limited: the domain of keys must
+## exclude the "innerDelim" and values and keys must exclude ",".
+## There is no facility for escaping, such as in escaped CSV.
+## This also leads to a further restriction that this representation is only
+## valid for maps and structs whose keys and values may all be encoded to string
+## form without conflicts in delimiter character. It is recommended, therefore,
+## that its use be limited to structs containing values with the basic data
+## model kinds that exclude multiple values (i.e. no maps, lists, and therefore
+## structs or unions).
+##
+type Representation_StringPairs struct {
+	innerDelim String
+	entryDelim String
+}
+
+## Representation_ListPairs describes that a map, or struct, should
+## be encoded as a as a list in the IPLD Data Model. This list comprises
+## a sub-list for each entry, in the form: [[k1,v1],[k2,v2]].
+##
+## This representation type is similar to StructRepresentation_Tuple except
+## it includes the keys. In the case of maps, this is critical since the
+## keys are not defined in the schema (hence "tuple" representation isn't
+## available for maps), but is optional for structs since they are. A tuple
+## representation for a struct will encode more compact than listpairs.
+##
+type Representation_ListPairs struct {}
 
 ## TypeList describes a list.
 ## The values of the list have some specific type of their own.
@@ -368,6 +418,9 @@ type InlineDefn union {
 type StructRepresentation union {
 	| StructRepresentation_Map "map"
 	| StructRepresentation_Tuple "tuple"
+	| Representation_StringPairs "stringpairs"
+	| StructRepresentation_StringJoin "stringjoin"
+	| Representation_listpairs "listpairs"
 } representation keyed
 
 ## StructRepresentation_Map describes a way to map a struct type onto a map
@@ -416,6 +469,23 @@ type StructRepresentation_Map_FieldDetails struct {
 ## field order can be specified in order to override the order defined
 ## in the type, but optionals and implicits are not (currently) supported.
 type StructRepresentation_Tuple struct {
+	fieldOrder optional [String]
+}
+
+## StructRepresentation_StringJoin describes a way to encode a struct to
+## a string in the IPLD Data Model. Similar to tuple representation, the
+## keys are dropped as they may be inferred from the struct definition.
+## values are concatenated, in order, and separated by a "join" delimiter.
+## For example, specifying ":" as the "join": "v1,v2,v3".
+##
+## stringjoin is necessarily restrictive and therefore only valid for structs
+## whose values may all be encoded to string form without conflicts in "join"
+## character. It is recommended, therefore, that its use be limited to structs
+## containing values with the basic data model kinds that exclude multiple
+## values (i.e. no maps, lists, and therefore structs or unions).
+##
+type StructRepresentation_StringJoin struct {
+	join String
 	fieldOrder optional [String]
 }
 

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -112,6 +112,9 @@
 				},
 				"valueNullable": {
 					"type": "Bool"
+				},
+				"representation": {
+					"type": "MapRepresentation"
 				}
 			},
 			"representation": {
@@ -122,6 +125,44 @@
 						}
 					}
 				}
+			}
+		},
+		"MapRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"map": "MapRepresentation_Map",
+					"stringpairs": "Representation_StringPairs",
+					"listpairs": "Representation_ListPairs"
+				}
+			}
+		},
+		"MapRepresentation_Map": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
+			}
+		},
+		"Representation_StringPairs": {
+			"kind": "struct",
+			"fields": {
+				"innerDelim": {
+					"type": "String"
+				},
+				"entryDelim": {
+					"type": "String"
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"Representation_ListPairs": {
+			"kind": "struct",
+			"fields": {},
+			"representation": {
+				"map": {}
 			}
 		},
 		"TypeList": {
@@ -302,7 +343,10 @@
 			"representation": {
 				"keyed": {
 					"map": "StructRepresentation_Map",
-					"tuple": "StructRepresentation_Tuple"
+					"tuple": "StructRepresentation_Tuple",
+					"stringpairs": "Representation_StringPairs",
+					"stringjoin": "StructRepresentation_StringJoin",
+					"listpairs": "Representation_listpairs"
 				}
 			}
 		},
@@ -341,6 +385,24 @@
 		"StructRepresentation_Tuple": {
 			"kind": "struct",
 			"fields": {
+				"fieldOrder": {
+					"type": {
+						"kind": "list",
+						"valueType": "String"
+					},
+					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_StringJoin": {
+			"kind": "struct",
+			"fields": {
+				"join": {
+					"type": "String"
+				},
 				"fieldOrder": {
 					"type": {
 						"kind": "list",

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -279,7 +279,7 @@
 				"fields": {
 					"type": {
 						"kind": "map",
-						"keyType": "String",
+						"keyType": "FieldName",
 						"valueType": "StructField"
 					}
 				},
@@ -290,6 +290,9 @@
 			"representation": {
 				"map": {}
 			}
+		},
+		"FieldName": {
+			"kind": "string"
 		},
 		"StructField": {
 			"kind": "struct",
@@ -356,7 +359,7 @@
 				"fields": {
 					"type": {
 						"kind": "map",
-						"keyType": "String",
+						"keyType": "FieldName",
 						"valueType": "StructRepresentation_Map_FieldDetails"
 					},
 					"optional": true

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -132,8 +132,8 @@
 			"representation": {
 				"keyed": {
 					"map": "MapRepresentation_Map",
-					"stringpairs": "Representation_StringPairs",
-					"listpairs": "Representation_ListPairs"
+					"stringpairs": "MapRepresentation_StringPairs",
+					"listpairs": "MapRepresentation_ListPairs"
 				}
 			}
 		},
@@ -144,7 +144,7 @@
 				"map": {}
 			}
 		},
-		"Representation_StringPairs": {
+		"MapRepresentation_StringPairs": {
 			"kind": "struct",
 			"fields": {
 				"innerDelim": {
@@ -158,7 +158,7 @@
 				"map": {}
 			}
 		},
-		"Representation_ListPairs": {
+		"MapRepresentation_ListPairs": {
 			"kind": "struct",
 			"fields": {},
 			"representation": {
@@ -347,9 +347,9 @@
 				"keyed": {
 					"map": "StructRepresentation_Map",
 					"tuple": "StructRepresentation_Tuple",
-					"stringpairs": "Representation_StringPairs",
+					"stringpairs": "StructRepresentation_StringPairs",
 					"stringjoin": "StructRepresentation_StringJoin",
-					"listpairs": "Representation_listpairs"
+					"listpairs": "StructRepresentation_ListPairs"
 				}
 			}
 		},
@@ -391,9 +391,23 @@
 				"fieldOrder": {
 					"type": {
 						"kind": "list",
-						"valueType": "String"
+						"valueType": "FieldName"
 					},
 					"optional": true
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_StringPairs": {
+			"kind": "struct",
+			"fields": {
+				"innerDelim": {
+					"type": "String"
+				},
+				"entryDelim": {
+					"type": "String"
 				}
 			},
 			"representation": {
@@ -409,11 +423,18 @@
 				"fieldOrder": {
 					"type": {
 						"kind": "list",
-						"valueType": "String"
+						"valueType": "FieldName"
 					},
 					"optional": true
 				}
 			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"StructRepresentation_ListPairs": {
+			"kind": "struct",
+			"fields": {},
 			"representation": {
 				"map": {}
 			}


### PR DESCRIPTION
Brings schema-schema into parity with https://github.com/ipld/specs/blob/master/schemas/representations.md

Adds stringpairs, listpairs, stringjoin for map and struct as appropriate.

The `Representation_StringPairs` and `Representation_ListPairs` structs are without the prefixes (`Struct` and `Map`) because they are shared between both. This works out nicely in code too but I'm not sure if it's the best way to do it here?

schema-schema.ipldsch.json generated by js-ipld-schema