### PR TITLE
schemas: replace "alias" with "rename"

### DIFF
--- a/schemas/examples.ipldsch
+++ b/schemas/examples.ipldsch
@@ -1,8 +1,8 @@
 
-type ExampleWithNullable map {String : nullable String}
+type ExampleWithNullable {String : nullable String}
 
 type ExampleWithAnonDefns struct {
-	fooField optional {String:String} (alias "foo_field")
+	fooField optional {String:String} (rename "foo_field")
 	barField nullable {String:String}
 	bazField {String : nullable String}
 	wozField {String:[nullable String]}

--- a/schemas/examples.ipldsch.json
+++ b/schemas/examples.ipldsch.json
@@ -47,8 +47,10 @@
 			},
 			"representation": {
 				"map": {
-					"fieldAliases": {
-						"fooField": "foo_field"
+					"fields": {
+						"fooField": {
+							"rename": "foo_field"
+						}
 					}
 				}
 			}

--- a/schemas/overview.md
+++ b/schemas/overview.md
@@ -43,8 +43,9 @@ All of this maps over the IPLD Data Model:
 
 - every type has a representation;
 - e.g. maps are represented as maps; structs are also represented as maps!
-- representations can specify aliases for how to serialize things; e.g. provide
-  shorter serial strings to use in place of longer struct names.
+- representations can specify a mapping for serialized field names, which can
+  be useful in cases such as requiring serialization compactness but preferring
+  verbosity in the schema for descriptive purposes.
 - representations are customizable, including mapping a type onto a different
   representation kind entirely!  e.g. a struct can be declared to have a
   list representation (making it shorter to serialize, if less self-describing);

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -364,19 +364,27 @@ type InlineDefn union {
 ## StructRepresentation describes how a struct type should be mapped onto
 ## its IPLD Data Model representation.  Typically, maps are the representation
 ## kind, but other kinds and details can be configured.
+##
 type StructRepresentation union {
 	| StructRepresentation_Map "map"
 	| StructRepresentation_Tuple "tuple"
 } representation keyed
 
 ## StructRepresentation_Map describes a way to map a struct type onto a map
-## representation.  For example, fields may be aliased,
-## or implicit values associated.
+## representation. Field serialization options may optionally be configured to
+## enable mapping serialized keys using the 'rename' option, or implicit values
+## specified where the field is omitted from the serialized form using the
+## 'implicit' option.
+##
+## See StructRepresentation_Map_FieldDetails for details on the 'rename' and
+## 'implicit' options.
+##
 type StructRepresentation_Map struct {
 	fields optional {String:StructRepresentation_Map_FieldDetails}
 }
+
 ## StructRepresentation_Map_FieldDetails describes additional properties of a
-## struct field when represented as a map.  For example, fields may be aliased,
+## struct field when represented as a map.  For example, fields may be renamed,
 ## or implicit values associated.
 ##
 ## If an implicit value is defined, then during marshalling, if the actual value
@@ -391,13 +399,13 @@ type StructRepresentation_Map struct {
 ## By contrast, the cardinality of membership of a field with an implicit value
 ## remains unchanged; there is serial state which can map to an undefined value.
 ##
-## Note that 'alias' supports exactly one string, and not a list: this is
-## intentional.  The alias feature is meant to allow serial representations
+## Note that 'rename' supports exactly one string, and not a list: this is
+## intentional.  The rename feature is meant to allow serial representations
 ## to use a different key string than the schema type definition field name;
 ## it is not intended to be used for migration purposes.
 ##
 type StructRepresentation_Map_FieldDetails struct {
-	alias optional String
+	rename optional String
 	implicit optional Any # Review: may be better to introduce a small kinded union here which has the essential scalars as members.
 }
 

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -325,7 +325,7 @@
 		"StructRepresentation_Map_FieldDetails": {
 			"kind": "struct",
 			"fields": {
-				"alias": {
+				"rename": {
 					"type": "String",
 					"optional": true
 				},


### PR DESCRIPTION
This has been floating around and mostly adopted in Goland. A better word than "alias" for a translation of the key to the serialized form.

JS support @ https://github.com/rvagg/js-ipld-schema/pull/6

Test fixture of

```ipldsch
  type StructAsMapWithRenames struct {
    bar Bool (rename "b")
    boom String
    baz String (rename "z")
    foo Int (implicit "0" rename "f")
  }
```
comes out as

```json
  {
    "StructAsMapWithRenames": {
      "kind": "struct",
      "fields": {
        "bar": {
          "type": "Bool"
        },
        "boom": {
          "type": "String"
        },
        "baz": {
          "type": "String"
        },
        "foo": {
          "type": "Int"
        }
      },
      "representation": {
        "map": {
          "fields": {
            "bar": { "rename": "b" },
            "baz": { "rename": "z" },
            "foo": {
              "implicit": 0,
              "rename": "f"
            }
          }
        }
      }
    }
```