### PR TITLE
schemas: specify Any and AnyScalar

### DIFF
--- a/schemas/examples.ipldsch
+++ b/schemas/examples.ipldsch
@@ -1,9 +1,10 @@
 
-type ExampleWithNullable {String : nullable String}
+type ExampleWithNullable {String : nullable &Any}
 
 type ExampleWithAnonDefns struct {
 	fooField optional {String:String} (rename "foo_field")
 	barField nullable {String:String}
 	bazField {String : nullable String}
 	wozField {String:[nullable String]}
+	boomField &ExampleWithNullable
 } representation map

--- a/schemas/examples.ipldsch.json
+++ b/schemas/examples.ipldsch.json
@@ -3,7 +3,9 @@
 		"ExampleWithNullable": {
 			"kind": "map",
 			"keyType": "String",
-			"valueType": "String",
+			"valueType": {
+				"kind": "link"
+			},
 			"valueNullable": true
 		},
 		"ExampleWithAnonDefns": {
@@ -42,6 +44,12 @@
 							"valueType": "String",
 							"valueNullable": true
 						}
+					}
+				},
+				"boomField": {
+					"type": {
+						"kind": "link",
+						"expectedType": "ExampleWithNullable"
 					}
 				}
 			},

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -135,6 +135,18 @@ type RepresentationKind enum {
 	| "link"
 }
 
+## AnyScalar defines a union of the basic non-complex kinds.
+##
+## Useful defining usage of IPLD nodes that do compose from other nodes.
+##
+type AnyScalar union {
+	| Bool bool
+	| String string
+	| Bytes bytes
+	| Int int
+	| Float float
+} representation kinded
+
 ## TypeBool describes a simple boolean type.
 ## It has no details.
 ##
@@ -178,15 +190,25 @@ type TypeList struct {
 } representation map
 
 ## TypeLink describes a hash linking to another object (a CID).
+##
 ## A link also has an "expectedType" that provides a hinting mechanism
 ## suggesting what we should find if we were to follow the link. This
 ## cannot be strictly enforced by a node or block-level schema
 ## validation but may be enforced elsewhere in an application relying on
 ## a schema.
+##
 ## The expectedType is specified with the `&Any` link shorthand, where
 ## `Any` may be replaced with a specific type.
+##
+## Unlike other kinds, we use `&Type` to denote a link Type rather than
+## `Link`. In this usage, we replace `Type` the expected Type, with `&Any`
+## being shorthand for "a link which may resolve to a type of any kind".
+##
+## `expectedType` is a String, but it should validate as "Any" or a TypeName
+## found somewhere in the schema.
+##
 type TypeLink struct {
-	expectedType TypeTerm (implicit "Any")
+	expectedType String (implicit "Any")
 }
 
 ## TypeUnion describes a union (sometimes called a "sum type", or
@@ -406,7 +428,7 @@ type StructRepresentation_Map struct {
 ##
 type StructRepresentation_Map_FieldDetails struct {
 	rename optional String
-	implicit optional Any # Review: may be better to introduce a small kinded union here which has the essential scalars as members.
+	implicit optional AnyScalar
 }
 
 ## StructRepresentation_Tuple describes a way to map a struct type into a list

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -66,6 +66,18 @@
 				"link": null
 			}
 		},
+		"AnyScalar": {
+			"kind": "union",
+			"representation": {
+				"kinded": {
+					"bool": "Bool",
+					"string": "String",
+					"bytes": "Bytes",
+					"int": "Int",
+					"float": "Float"
+				}
+			}
+		},
 		"TypeBool": {
 			"kind": "struct",
 			"fields": {},
@@ -148,7 +160,7 @@
 			"kind": "struct",
 			"fields": {
 				"expectedType": {
-					"type": "TypeTerm"
+					"type": "String"
 				}
 			},
 			"representation": {
@@ -330,7 +342,7 @@
 					"optional": true
 				},
 				"implicit": {
-					"type": "Any",
+					"type": "AnyScalar",
 					"optional": true
 				}
 			},


### PR DESCRIPTION
First attempt at specifying `Any`, also introduces `AnyScalar` and adds some words about `&` usage into `TypeLink` comments. The example.ipldsch is also adjusted to include links and it has the missing `"expectedType"` where it's `Any` in the first instance.