### PR TITLE
schema: introduce byteprefix union representation strategy

### DIFF
--- a/schemas/representations.md
+++ b/schemas/representations.md
@@ -43,6 +43,7 @@ Link is also not described in this section, as it's a rather unique business.)
 	- `kinded` representation -- transcribes to varying (!) kinds in the Data Model.
 	- `envelope` representation -- transcribes to a dual-entry `map` in the Data Model.
 	- `inline` representation -- transcribes to a `map` in the Data Model (and has additional limitations).
+	- `byteprefix` representation -- transcribes to `bytes` in the Data Model, only usable for unions of `bytes`.
 - Struct
 	- `map` representation -- the default -- transcribes to `map` in the Data Model.
 	- `tuple` representation -- transcribes to `list` in the Data Model.
@@ -291,3 +292,19 @@ This is because inline unions are only a defined concept when working with types
 that have a map representation -- so, our `Bar` type in the previously examples,
 which was of `int` kind, doesn't work for this example.  We replaced it with
 another struct type, which -- since it has a `map` representation -- works.
+
+#### union byteprefix representation example
+
+```ipldsch
+type Signature union {
+	| Secp256k1Signature 0
+	| Bls12_381Signature 1
+} representation byteprefix
+
+type Secp256k1Signature bytes
+type Bls12_381Signature bytes
+```
+
+At the block level, this presents as a byte array, where the first byte is the discriminator (`0x00` or `0x01`) and the remainder is sliced to form either of the two types depending on the discriminator.
+
+`byteprefix` is not valid for unions where any of the constitutive types are _not_ `Bytes`.

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -342,10 +342,18 @@ type TypeUnion struct {
 ## UnionRepresentation is a union of all the distinct ways a TypeUnion's values
 ## can be mapped onto a serialized format for the IPLD Data Model.
 ##
-## There are "keyed", "envelop", and "inline" strategies, which are all ways
-## to produce representations in a map format (some literature may describe
-## this as "tagged" style unions), and a fourth style, "kinded" unions, may
-## actually encode itself as any of the other representation kinds!
+## There are five strategies that can be used to encode a union:
+## "keyed", "envelope", "inline", "byteprefix", and "kinded".
+## The "keyed", "envelope", and "inline" strategies are all ways to produce
+## representations in a map format, using map keys as type discriminators
+## (some literature may describe this as a "tagged" style of union).
+## The "byteprefix" strategy, only available only for unions in which all
+## member types themselves represent as bytes in the data model, uses another
+## byte as the type discrimination hint (and like the map-oriented strategies,
+## may also be seen as a form of "tagged" style unions).
+## The "kinded" strategy can describe a union in which member types have
+## several different representation kinds, and uses the representation kind
+## itself as the type discrimination hint to do so.
 ##
 ## Note: Unions can be used to produce a "nominative" style of type declarations
 ## -- yes, even given that IPLD Schema systems are natively "structural" typing!
@@ -355,6 +363,7 @@ type UnionRepresentation union {
 	| UnionRepresentation_Keyed "keyed"
 	| UnionRepresentation_Envelope "envelope"
 	| UnionRepresentation_Inline "inline"
+	| UnionRepresentation_BytePrefix "byteprefix"
 } representation keyed
 
 ## "Kinded" union representations describe a bidirectional mapping between
@@ -406,6 +415,18 @@ type UnionRepresentation_Envelope struct {
 type UnionRepresentation_Inline struct {
 	discriminantKey String
 	discriminantTable {String:TypeName}
+}
+
+## UnionRepresentation_BytePrefix describes a union representation for unions
+## whose member types are all bytes. It is encoded to a byte array whose
+## first byte is the discriminator and subsequent bytes form the discriminated
+## type.
+##
+## byteprefix is an invalid representation for any union that contains a type
+## that does not have a bytes representation.
+##
+type UnionRepresentation_BytePrefix struct {
+	discriminantTable {TypeName:Int}
 }
 
 ## TypeStruct describes a type which has a group of fields of varying Type.

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -293,7 +293,8 @@
 					"kinded": "UnionRepresentation_Kinded",
 					"keyed": "UnionRepresentation_Keyed",
 					"envelope": "UnionRepresentation_Envelope",
-					"inline": "UnionRepresentation_Inline"
+					"inline": "UnionRepresentation_Inline",
+					"byteprefix": "UnionRepresentation_BytePrefix"
 				}
 			}
 		},
@@ -339,6 +340,21 @@
 						"kind": "map",
 						"keyType": "String",
 						"valueType": "TypeName"
+					}
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"UnionRepresentation_BytePrefix": {
+			"kind": "struct",
+			"fields": {
+				"discriminantTable": {
+					"type": {
+						"kind": "map",
+						"keyType": "TypeName",
+						"valueType": "Int"
 					}
 				}
 			},


### PR DESCRIPTION
Introduced in Filecoin, not an unreasonable representation strategy for a union types that are all represented as bytes.

Ref: https://github.com/filecoin-project/specs/