### PR TITLE
schema: int representation for enums

### DIFF
--- a/schemas/representations.md
+++ b/schemas/representations.md
@@ -1,6 +1,20 @@
 Kinds and their Representations
 -------------------------------
 
+* [Kinds and their Representations](#kinds-and-their-representations)
+* [Available representations](#available-representations)
+* [Representation Strategy Reference](#representation-strategy-reference)
+  * [struct map representation](#struct-map-representation)
+  * [struct tuple representation](#struct-tuple-representation)
+  * [struct stringjoin representation](#struct-stringjoin-representation)
+  * [map stringpairs representation](#map-stringpairs-representation)
+  * [union keyed representation](#union-keyed-representation)
+  * [union kinded representation](#union-kinded-representation)
+  * [union envelope representation](#union-envelope-representation)
+  * [union inline representation](#union-inline-representation)
+  * [enum string representation](#enum-string-representation)
+  * [enum int representation](#enum-int-representation)
+
 A type at the Schema level must be mapped onto a representation expressible
 within the Data Model.
 
@@ -26,7 +40,7 @@ more detailed parameters which are specific to the strategy (e.g., the struct
 map representation has a concept of 'default' values which is unique to that
 strategy).
 
-### table
+## Available representations
 
 (Kinds for which no meaningful customization is possible -- Null, Boolean,
 Integer, Float, String, Bytes, and List -- are elided.
@@ -52,19 +66,17 @@ Link is also not described in this section, as it's a rather unique business.)
 	- `listpairs` representation -- transcribes to `list` (of lists) in the Data Model.
 - Enum
 	- `string` representation -- the default -- transcribes the enum values as `string` in the Data Model.
+	- `int` representation -- transcribes the enum values as `int` in the Data Model.
 
 Each of these representation strategies will be explored in detail in the
 "Representation Strategy Reference" section, below.
 
-
-Representation Strategy Reference
----------------------------------
+## Representation Strategy Reference
 
 In this section, we'll go into detail on each representation strategy,
 and include examples of both schemas using it and data matching it.
 See the "Kinds and their Representations" section for an introduction to
 representation strategies.
-
 
 ### struct map representation
 
@@ -72,7 +84,7 @@ Map representation of structs means that the struct is represented as a map,
 where the keys are the names of the struct fields.  This is a common and
 natural way to represent structs; it's thus their default representation.
 
-#### struct map representation example
+**Example**
 
 ```ipldsch
 type Foo struct {
@@ -93,7 +105,6 @@ Some data matching the `Foo` struct (shown as JSON) is:
 }
 ```
 
-
 ### struct tuple representation
 
 Tuple representation allows structs to be packed into a list representation.
@@ -106,7 +117,7 @@ in the way of "self-describing" information, tuple representations can make for
 very fragile protocols, increase the difficulty of migrations, and make
 serialized data incomprehensible without the schema information in hand.
 
-#### struct tuple representation example
+**Example**
 
 ```ipldsch
 type Foo struct {
@@ -126,7 +137,7 @@ Notice how this is the same data as in the
 it's just much more compact than it was in the map representation (and
 beware -- correspondingly less self-describing!).
 
-#### struct stringjoin representation example
+### struct stringjoin representation
 
 ```ipldsch
 ## Fizzlebop is a pair of fields which serializes as "value-of-a:value-of-b" as a string.
@@ -147,7 +158,7 @@ Some data matching the `Fizzlebop` struct (shown as JSON) is:
 Since this is a struct, and none of the fields are optional, it *must* have two fields:
 therefore, a string with no `":"` characters would be rejected as not matching.
 
-#### map stringpairs representation example
+### map stringpairs representation
 
 Say we're doing something awfully like the mount options in an /etc/fstab file:
 
@@ -167,7 +178,7 @@ Some data matching the `MountOptions` struct (shown as JSON) is:
 "keys=values,serialized=thusly"
 ```
 
-#### union keyed representation example
+### union keyed representation
 
 ```ipldsch
 type MyKeyedUnion union {
@@ -191,7 +202,7 @@ This data would also match, as the other type:
 {"bar": 12}
 ```
 
-#### union kinded representation example
+### union kinded representation
 
 ```ipldsch
 type MyKindedUnion union {
@@ -233,7 +244,7 @@ Note that the kinds valid in a kinded union are all Data Model-layer
 `struct` is not.  The kind that a union member type is tagged with must
 match that type's representation kind or the schema is invalid.
 
-#### union envelope representation example
+### union envelope representation
 
 ```ipldsch
 type MyEnvelopeUnion union {
@@ -260,7 +271,7 @@ This data would also match, as the other type:
 {"tag":"bar", "msg":12}
 ```
 
-#### union inline representation example
+### union inline representation
 
 ```ipldsch
 type MyInlineUnion union {
@@ -308,3 +319,44 @@ type Bls12_381Signature bytes
 At the block level, this presents as a byte array, where the first byte is the discriminator (`0x00` or `0x01`) and the remainder is sliced to form either of the two types depending on the discriminator.
 
 `byteprefix` is not valid for unions where any of the constitutive types are _not_ `Bytes`.
+
+### enum string representation
+
+By default, an enum is simply represented as a string in the data model. An
+`enum` in the schema simply defines the list of possible strings that could be
+used in that position.
+
+**Example**
+
+```ipldsch
+type Status enum {
+	| NOPE
+	| YEP
+	| MAYBE
+}
+```
+
+This enum dictates that where `Status` is used, we should find one of `"NOPE"`,
+`"YEP"` or `"MAYBE"`.  No other value is valid where `Status` is used.
+
+### enum int representation
+
+An alternative representation for enums is the "int" representation that is
+closer to what users may expect from enums in certain programming languages
+that map enum values to integers. In IPLD Schemas we explicitly define the
+mapping to integers, so the user can dictate the appropriate data model values.
+
+**Example**
+
+```ipldsch
+type Status enum {
+	| NOPE  0
+	| YEP   1
+	| MAYBE 100
+} representation int
+```
+
+Note that for an "int" representation enum we don't quote the strings as they
+are no longer our data model values. Instead, the ints provided after each of
+the names are the values we find in the data model. In this case, this enum
+dictates that where `Status` is used, we should find one of `0`, `1` or `100`.

--- a/schemas/representations.md
+++ b/schemas/representations.md
@@ -339,6 +339,22 @@ type Status enum {
 This enum dictates that where `Status` is used, we should find one of `"NOPE"`,
 `"YEP"` or `"MAYBE"`.  No other value is valid where `Status` is used.
 
+Where the serialized strings are different to the values used for the enum, they
+may be provided in parens:
+
+**Example**
+
+```ipldsch
+type Status enum {
+	| NOPE ("NAY")
+	| YEP  ("YAY")
+	| MAYBE
+}
+```
+
+In this example, the serialization expects, and uses, the strings `NAY`, `YAY`
+and `MAYBE`.
+
 ### enum int representation
 
 An alternative representation for enums is the "int" representation that is
@@ -350,13 +366,17 @@ mapping to integers, so the user can dictate the appropriate data model values.
 
 ```ipldsch
 type Status enum {
-	| NOPE  0
-	| YEP   1
-	| MAYBE 100
+	| NOPE  ("0")
+	| YEP   ("1")
+	| MAYBE ("100")
 } representation int
 ```
 
-Note that for an "int" representation enum we don't quote the strings as they
-are no longer our data model values. Instead, the ints provided after each of
-the names are the values we find in the data model. In this case, this enum
-dictates that where `Status` is used, we should find one of `0`, `1` or `100`.
+As with the "string" representaiton, "int" representation enums still quote the
+integer strings. Schema tooling will convert them to integers when using.
+
+There are no optional values, as for "string" representation enums, all values
+must be provided when using "int" representation enums.
+
+In our example, serialization expects, and uses, data model integer values `0`,
+`1`, and `100`. No other values at this position are valid.

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -644,9 +644,22 @@ type StructRepresentation_ListPairs struct {}
 ## when using the default "string" representation, or when using an "int"
 ## representation, an integer must also be supplied along with the EnumValue.
 ##
+## Integer and string values (for int and string representations respectively)
+## are provided in parens in the DSL. Where the string used in serialization is
+## the same as the EnumValue, it may be omitted. For int representation enums,
+## all int values are required.
+##
 type TypeEnum struct {
+  members {EnumValue:Null}
 	representation EnumRepresentation
 }
+
+## EnumValue is a string that has limitations for use as a member of an enum
+## set. The rules for EnumValue are the same as for TypeName but without the
+## convention of an uppercase first character. Capitalization is left up to
+## the user.
+##
+type EnumValue string
 
 ## EnumRepresentation describes how an enum type should be mapped onto
 ## its IPLD Data Model representation. By default an enum is represented as a
@@ -657,22 +670,18 @@ type EnumRepresentation union {
 	| EnumRepresentation_Int "int"
 } representation keyed
 
-## EnumValue is a string that has limitations for use as a member of an enum
-## set. The rules for EnumValue are the same as for TypeName but without the
-## convention of an uppercase first character. Capitalization is left up to
-## the user.
-##
-type EnumValue string
-
 ## EnumRepresentation_String describes the way an enum is represented as a
-## string in the data model. A mapping of name to null is recorded for
-## convenient look-up of valid enum strings.
+## string in the data model. By default, the strings used as EnumValue will be
+## used at the serialization. A custom string may be provided (with `Foo ("x")`
+## in the DSL) which will be stored here in the representation block. Missing
+## entries in this map will use the default.
 ##
-type EnumRepresentation_String {EnumValue:Null}
+type EnumRepresentation_String {EnumValue:String}
 
 ## EnumRepresentation_Int describes the way an enum is represented as an int
 ## in the data model. A mapping of names to ints is required to perform the
-## conversion from int to enum value.
+## conversion from int to enum value. In the DSL, int values _must_ be provided
+## for each EnumValue (with `Foo ("100")`, those are stored here.
 ##
 type EnumRepresentation_Int {EnumValue:Int}
 

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -117,18 +117,17 @@ type Type union {
 ## TODO: not actually sure we'll need to declare this.  Only usage is
 ## in the Type union representation details?
 type TypeKind enum {
-	| "bool"
-	| "string"
-	| "bytes"
-	| "int"
-	| "float"
-	| "map"
-	| "list"
-	| "link"
-	| "union"
-	| "struct"
-	| "enum"
-	| "copy"
+	| Bool
+	| String
+	| Bytes
+	| Int
+	| Float
+	| Map
+	| List
+	| Link
+	| Union
+	| Struct
+	| Enum
 }
 
 ## RepresentationKind is similar to TypeKind, but includes only those concepts
@@ -145,14 +144,14 @@ type TypeKind enum {
 ## definition in the details of Type; for example, they're used describing
 ## some of the detailed behaviors of a "kinded"-style union type.
 type RepresentationKind enum {
-	| "bool"
-	| "string"
-	| "bytes"
-	| "int"
-	| "float"
-	| "map"
-	| "list"
-	| "link"
+	| Bool
+	| String
+	| Bytes
+	| Int
+	| Float
+	| Map
+	| List
+	| Link
 }
 
 ## AnyScalar defines a union of the basic non-complex kinds.
@@ -641,11 +640,41 @@ type StructRepresentation_StringJoin struct {
 type StructRepresentation_ListPairs struct {}
 
 ## TypeEnum describes a type which has a known, pre-defined set of possible
-## values.  Each of the values must be representable a string.
+## values. Each of the values must be representable as a string (EnumValue)
+## when using the default "string" representation, or when using an "int"
+## representation, an integer must also be supplied along with the EnumValue.
 ##
 type TypeEnum struct {
-	members {String:Null}
+	representation EnumRepresentation
 }
+
+## EnumRepresentation describes how an enum type should be mapped onto
+## its IPLD Data Model representation. By default an enum is represented as a
+## string kind but it may also be represented as an int kind.
+##
+type EnumRepresentation union {
+	| EnumRepresentation_String "string"
+	| EnumRepresentation_Int "int"
+} representation keyed
+
+## EnumValue is a string that has limitations for use as a member of an enum
+## set. The rules for EnumValue are the same as for TypeName but without the
+## convention of an uppercase first character. Capitalization is left up to
+## the user.
+##
+type EnumValue string
+
+## EnumRepresentation_String describes the way an enum is represented as a
+## string in the data model. A mapping of name to null is recorded for
+## convenient look-up of valid enum strings.
+##
+type EnumRepresentation_String {EnumValue:Null}
+
+## EnumRepresentation_Int describes the way an enum is represented as an int
+## in the data model. A mapping of names to ints is required to perform the
+## conversion from int to enum value.
+##
+type EnumRepresentation_Int {EnumValue:Int}
 
 ## TypeCopy describes a special "copy" unit that indicates that a type name
 ## should copy the type descriptor of another type. TypeCopy does not redirect a

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -54,32 +54,35 @@
 		},
 		"TypeKind": {
 			"kind": "enum",
-			"members": {
-				"bool": null,
-				"string": null,
-				"bytes": null,
-				"int": null,
-				"float": null,
-				"map": null,
-				"list": null,
-				"link": null,
-				"union": null,
-				"struct": null,
-				"enum": null,
-				"copy": null
+			"representation": {
+				"string": {
+					"bool": null,
+					"string": null,
+					"bytes": null,
+					"int": null,
+					"float": null,
+					"map": null,
+					"list": null,
+					"link": null,
+					"union": null,
+					"struct": null,
+					"enum": null
+				}
 			}
 		},
 		"RepresentationKind": {
 			"kind": "enum",
-			"members": {
-				"bool": null,
-				"string": null,
-				"bytes": null,
-				"int": null,
-				"float": null,
-				"map": null,
-				"list": null,
-				"link": null
+			"representation": {
+				"string": {
+					"bool": null,
+					"string": null,
+					"bytes": null,
+					"int": null,
+					"float": null,
+					"map": null,
+					"list": null,
+					"link": null
+				}
 			}
 		},
 		"AnyScalar": {
@@ -533,17 +536,35 @@
 		"TypeEnum": {
 			"kind": "struct",
 			"fields": {
-				"members": {
-					"type": {
-						"kind": "map",
-						"keyType": "String",
-						"valueType": "Null"
-					}
+				"representation": {
+					"type": "EnumRepresentation"
 				}
 			},
 			"representation": {
 				"map": {}
 			}
+		},
+		"EnumRepresentation": {
+			"kind": "union",
+			"representation": {
+				"keyed": {
+					"string": "EnumRepresentation_String",
+					"int": "EnumRepresentation_Int"
+				}
+			}
+		},
+		"EnumValue": {
+			"kind": "string"
+		},
+		"EnumRepresentation_String": {
+			"kind": "map",
+			"keyType": "EnumValue",
+			"valueType": "Null"
+		},
+		"EnumRepresentation_Int": {
+			"kind": "map",
+			"keyType": "EnumValue",
+			"valueType": "Int"
 		},
 		"TypeCopy": {
 			"kind": "struct",

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -54,35 +54,37 @@
 		},
 		"TypeKind": {
 			"kind": "enum",
+			"members": {
+				"Bool": null,
+				"String": null,
+				"Bytes": null,
+				"Int": null,
+				"Float": null,
+				"Map": null,
+				"List": null,
+				"Link": null,
+				"Union": null,
+				"Struct": null,
+				"Enum": null
+			},
 			"representation": {
-				"string": {
-					"bool": null,
-					"string": null,
-					"bytes": null,
-					"int": null,
-					"float": null,
-					"map": null,
-					"list": null,
-					"link": null,
-					"union": null,
-					"struct": null,
-					"enum": null
-				}
+				"string": {}
 			}
 		},
 		"RepresentationKind": {
 			"kind": "enum",
+			"members": {
+				"Bool": null,
+				"String": null,
+				"Bytes": null,
+				"Int": null,
+				"Float": null,
+				"Map": null,
+				"List": null,
+				"Link": null
+			},
 			"representation": {
-				"string": {
-					"bool": null,
-					"string": null,
-					"bytes": null,
-					"int": null,
-					"float": null,
-					"map": null,
-					"list": null,
-					"link": null
-				}
+				"string": {}
 			}
 		},
 		"AnyScalar": {
@@ -536,6 +538,13 @@
 		"TypeEnum": {
 			"kind": "struct",
 			"fields": {
+				"members": {
+					"type": {
+						"kind": "map",
+						"keyType": "EnumValue",
+						"valueType": "Null"
+					 }
+				},
 				"representation": {
 					"type": "EnumRepresentation"
 				}
@@ -559,7 +568,7 @@
 		"EnumRepresentation_String": {
 			"kind": "map",
 			"keyType": "EnumValue",
-			"valueType": "Null"
+			"valueType": "String"
 		},
 		"EnumRepresentation_Int": {
 			"kind": "map",


### PR DESCRIPTION
I've done some non-trivial surgery here to make this happy. I copied the union representation structure in schema-schema and removed the innards of `enum`, pushing the "members" into the representations. So in schema-schema we have this:

```ipldsch
type RepresentationKind enum {
	| "bool"
	| "string"
	| "bytes"
	| "int"
	| "float"
	| "map"
	| "list"
	| "link"
}
```

maps to this

```json
		"RepresentationKind": {
			"kind": "enum",
			"representation": {
				"string": {
					"bool": null,
					"string": null,
					"bytes": null,
					"int": null,
					"float": null,
					"map": null,
					"list": null,
					"link": null
				}
			}
```

And as per the docs, I'm proposing that this (from Filecoin):

```ipldsch
type Options enum {
    | Blocks 0
    | Messages 1
    | BlocksAndMessages 2
} representation int
```

(note the unquoted strings this time)

would map to this:

```json
		"Options": {
			"kind": "enum",
			"representation": {
				"int": {
					"Blocks": 0,
					"Messages": 1,
					"BlocksAndMessages": 2
				}
			}
```

The mapping of `{String:Int}` isn't as convenient for lookups but I'm sure codegen could make that cost go away.

I also made some cosmetic alterations to representations.md while I was in there.