### PR TITLE
schemas: define a "copy" type

### DIFF
--- a/schemas/schema-kinds.md
+++ b/schemas/schema-kinds.md
@@ -2,8 +2,13 @@
 
 * [Extending the IPLD Data Model](#extending-the-ipld-data-model)
   * [Data Model Kinds](#data-model-kinds)
-  * [Recursive Kinds](#recursive-kinds)
-  * [Meta Kinds](#meta-kinds)
+  * [Schema Kinds](#schema-kinds)
+    * [List](#list)
+    * [Map](#map)
+    * [Union](#union)
+    * [Struct](#struct)
+    * [Enum](#enum)
+    * [Copy](#copy)
 * [Value Type Modifiers](#value-type-modifiers)
   * [Nullable Values](#nullable-values)
   * [Optional Fields](#optional-fields)
@@ -12,52 +17,100 @@
 * [Understanding Cardinality](#understanding-cardinality)
   * [Cardinality Examples](#cardinality-examples)
 
-
 ## Extending the IPLD Data Model
-
-IPLD Schemas define a set of "kinds" that are built upon the
-[IPLD Data Model](https://github.com/ipld/specs/blob/master/data-model-layer/data-model.md#kinds):
 
 ### Data Model Kinds
 
-  - **Null**
-  - **Boolean**
-  - **Integer**
-  - **Float**
-  - **String**
-  - **Bytes**
-  - **List**
-  - **Map**
-  - **Link**
+IPLD Schemas define a set of "kinds" that are built upon the
+[IPLD Data Model](https://github.com/ipld/specs/blob/master/data-model-layer/data-model.md#kinds).
+The Data Model defines the basic set of data types (kinds) that are easily
+representable by common programming languages and are supportable by expressive
+serialization formats such as JSON and CBOR. The Data Model defines its list of
+kinds as:
 
-### Recursive Kinds
+  * Null
+  * Boolean
+  * Integer
+  * Float
+  * String
+  * Bytes
+  * List
+  * Map
+  * Link
 
-The recursive (non-data model) kinds contain additional type definitions for
-either their keys (in the case of maps), values (in the case of maps and lists),
-or fields (in the case of structs). They are composed of data model kinds and
-provide the primary mechanism through which IPLD Schemas can be used to describe
-non-trivial data structures.
+### Schema Kinds
 
-  - **Union** - represented as a **map** in the data model for `keyed`,
-    `envelope` and `inline` representations, and varying data model kinds for
-    `kinded` unions, as described by [representations.md](representations.md).
-  - **Struct** - represented as a **map** in the data model by default but may be
-    used to describe **string** and **list** encodings, as described by
-    [representations.md](representations.md).
-  - **Enum** - represented as either a **string** or **int** in the data model,
-    as described by [representations.md](representations.md).
+IPLD Schemas, while built upon the data model, enables the definition of data
+structures that give us new discrete kinds, thus extending the Data Model Kinds
+into a new list of Schema Kinds:
 
-### Meta Kinds
+  * Null
+  * Boolean
+  * Integer
+  * Float
+  * String
+  * Bytes
+  * List
+  * Map
+  * Link
+  * **Union**
+  * **Struct**
+  * **Enum**
+  * **Copy**
 
-A meta kind is useful for simplifying schema authoring and/or increasing the
-descriptiveness of a schema for the purpose of documentation. It exists only
-within schema tooling and is not exposed to user-facing code or data.
+We define ***"Recursive Kinds"*** as the kinds that are comprised of other
+kinds: List, Map, Union, Struct, and Enum. These kinds provide the primary
+mechanism through which IPLD Schemas can be used to describe non-trivial
+data structures.
 
-  - **Copy** - a special kind that indicates that a type should be implemented
-    and encoded the same as another type but with an alternate name. This is a
-    short-hand to avoid defining multiple types of the same shape and encoding
-    but with different names.
+Further, we define Copy as a ***"Meta Kind"*** because it is useful for
+simplifying schema authoring and/or increasing the descriptiveness of a schema
+for the purpose of documentation. It exists only within schema tooling and is
+not exposed to user-facing code or data.
 
+#### List
+
+As a Schema Kind, Lists have more restrictions in the data they can contain. In
+the data model, a List is defined simply as a list of arbitrary data model
+kinds with no strict restrictions that may require uniformity. At the schema
+layer, a List is defined as a list of one specific schema type. For example,
+`type Foo [String]` defines a list of Strings, and _only_ matches a list of
+Strings. This restriction isn't as limiting as it may appear because Unions
+allow for significant flexibility, particularly in the case of `kinded` Unions.
+
+#### Map
+
+Similar to List, a Map at the schema layer requires a strict definition of the
+value types. The data model dictates that IPLD only supports string keys, so any
+type used as keys in schema Maps must be represented as strings. The value types
+have the same restrictions as for List element types. For example,
+`type Bar {String:Float}` matches a map with Float values, and _only_ Float
+values. But as in List, Unions allow for additional flexibility in the data
+model kinds that may appear as values.
+
+#### Union
+
+Unions are represented as a **Map** in the data model for `keyed`, `envelope`
+and `inline` representations, and varying data model kinds for `kinded` unions,
+as described by [representations.md](representations.md).
+
+#### Struct
+
+Structs are represented as a **Map** in the data model by default but may be
+used to describe **String** and **List** encodings, as described by
+[representations.md](representations.md).
+
+#### Enum
+
+Enums are represented as either a **String** or **Int** in the data model, as
+described by [representations.md](representations.md).
+
+#### Copy
+
+Copy is a Meta Kind that indicates that a type should be implemented and encoded
+the same as another type but with an alternate name. This is a short-hand to
+avoid defining multiple types of the same shape and encoding but with different
+names.
 
 ## Value Type Modifiers
 

--- a/schemas/schema-kinds.md
+++ b/schemas/schema-kinds.md
@@ -1,25 +1,34 @@
 Schema Kinds
 ------------
 
-Recursive types contain additional type definitions for either their
-keys (in the case of maps),
-values (in the case of maps and lists),
+IPLD Schemas define a set of "kinds" that are built upon the
+[IPLD Data Model](https://github.com/ipld/specs/blob/master/data-model-layer/data-model.md#kinds):
+
+ - **Null**
+ - **Boolean**
+ - **Integer**
+ - **Float**
+ - **String**
+ - **Bytes**
+ - **List**
+ - **Map**
+ - **Link**
+ - **Union** - represented as a **map** in the data model for `keyed`,
+   `envelope` and `inline` representations, and varying data model kinds for
+   `kinded` unions, as described by [representations.md](representations.md).
+ - **Struct** - represented as a **map** in the data model by default but may be
+   used to describe **string** and **list** encodings, as described by
+   [representations.md](representations.md).
+ - **Enum** - represented as either a **string** or **int** in the data model,
+   as described by [representations.md](representations.md).
+ - **Copy** - a special kind that indicates that a type should be implemented
+   and encoded the same as another type but with an alternate name. This is not
+   the same as an alias, but a short-hand to avoid defining multiple types of
+   the same shape and encoding but with different names.
+
+The recursive (non-data model) types contain additional type definitions for
+either their keys (in the case of maps), values (in the case of maps and lists),
 or fields (in the case of structs).
-
-### table
-
-- Null
-- Boolean
-- Integer
-- Float
-- String
-- Bytes
-- List
-- Map
-- Link
-- Union
-- Struct
-- Enum
 
 
 Value Type Modifiers

--- a/schemas/schema-kinds.md
+++ b/schemas/schema-kinds.md
@@ -1,38 +1,65 @@
-Schema Kinds
-------------
+# Schema Kinds
+
+* [Extending the IPLD Data Model](#extending-the-ipld-data-model)
+  * [Data Model Kinds](#data-model-kinds)
+  * [Recursive Kinds](#recursive-kinds)
+  * [Meta Kinds](#meta-kinds)
+* [Value Type Modifiers](#value-type-modifiers)
+  * [Nullable Values](#nullable-values)
+  * [Optional Fields](#optional-fields)
+  * [Fields with Defaults](#fields-with-defaults)
+  * [Combining Nullable, Optional, and Default](#combining-nullable-optional-and-default)
+* [Understanding Cardinality](#understanding-cardinality)
+  * [Cardinality Examples](#cardinality-examples)
+
+
+## Extending the IPLD Data Model
 
 IPLD Schemas define a set of "kinds" that are built upon the
 [IPLD Data Model](https://github.com/ipld/specs/blob/master/data-model-layer/data-model.md#kinds):
 
- - **Null**
- - **Boolean**
- - **Integer**
- - **Float**
- - **String**
- - **Bytes**
- - **List**
- - **Map**
- - **Link**
- - **Union** - represented as a **map** in the data model for `keyed`,
-   `envelope` and `inline` representations, and varying data model kinds for
-   `kinded` unions, as described by [representations.md](representations.md).
- - **Struct** - represented as a **map** in the data model by default but may be
-   used to describe **string** and **list** encodings, as described by
-   [representations.md](representations.md).
- - **Enum** - represented as either a **string** or **int** in the data model,
-   as described by [representations.md](representations.md).
- - **Copy** - a special kind that indicates that a type should be implemented
-   and encoded the same as another type but with an alternate name. This is not
-   the same as an alias, but a short-hand to avoid defining multiple types of
-   the same shape and encoding but with different names.
+### Data Model Kinds
 
-The recursive (non-data model) types contain additional type definitions for
+  - **Null**
+  - **Boolean**
+  - **Integer**
+  - **Float**
+  - **String**
+  - **Bytes**
+  - **List**
+  - **Map**
+  - **Link**
+
+### Recursive Kinds
+
+The recursive (non-data model) kinds contain additional type definitions for
 either their keys (in the case of maps), values (in the case of maps and lists),
-or fields (in the case of structs).
+or fields (in the case of structs). They are composed of data model kinds and
+provide the primary mechanism through which IPLD Schemas can be used to describe
+non-trivial data structures.
+
+  - **Union** - represented as a **map** in the data model for `keyed`,
+    `envelope` and `inline` representations, and varying data model kinds for
+    `kinded` unions, as described by [representations.md](representations.md).
+  - **Struct** - represented as a **map** in the data model by default but may be
+    used to describe **string** and **list** encodings, as described by
+    [representations.md](representations.md).
+  - **Enum** - represented as either a **string** or **int** in the data model,
+    as described by [representations.md](representations.md).
+
+### Meta Kinds
+
+A meta kind is useful for simplifying schema authoring and/or increasing the
+descriptiveness of a schema for the purpose of documentation. It exists only
+within schema tooling and is not exposed to user-facing code or data.
+
+  - **Copy** - a special kind that indicates that a type should be implemented
+    and encoded the same as another type but with an alternate name. This is a
+    short-hand to avoid defining multiple types of the same shape and encoding
+    but with different names.
 
 
-Value Type Modifiers
---------------------
+## Value Type Modifiers
 
 Values and fields in recursive types can have modifiers.
 
@@ -84,8 +111,7 @@ The `nullable` and `default` modifiers may be freely combined without issue.
 It is not valid to combine the `optional` and `default` modifiers.
 
 
-Understanding Cardinality
--------------------------
+## Understanding Cardinality
 
 ### Cardinality Examples
 

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -648,11 +648,11 @@ type TypeEnum struct {
 }
 
 ## TypeCopy describes a special "copy" unit that indicates that a type name
-## should copy the type descriptor of another type. While similar to an
-## "alias", a TypeCopy doesn't redirect a name to another type, it copies the
-## entire type definition and assigns it to another type.
+## should copy the type descriptor of another type. TypeCopy does not redirect a
+## name to another type. Instead, it copies the entire type definition and
+## assigns it to another type.
 ##
-## The DSL defines a TypeCopy as `type NewThing CopiedThing`, where
+## The DSL defines a TypeCopy as `type NewThing = CopiedThing`, where
 ## "CopiedThing" refers to a `type` defined elsewhere in a schema and is not
 ## one of TypeKind or an inline type descriptor (`{}`, `[]`, `&`).
 ##

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -105,6 +105,7 @@ type Type union {
 	| TypeUnion "union"
 	| TypeStruct "struct"
 	| TypeEnum "enum"
+	| TypeCopy "copy"
 } representation inline {
 	discriminantKey "kind"
 }
@@ -127,6 +128,7 @@ type TypeKind enum {
 	| "union"
 	| "struct"
 	| "enum"
+	| "copy"
 }
 
 ## RepresentationKind is similar to TypeKind, but includes only those concepts
@@ -643,4 +645,17 @@ type StructRepresentation_ListPairs struct {}
 ##
 type TypeEnum struct {
 	members {String:Null}
+}
+
+## TypeCopy describes a special "copy" unit that indicates that a type name
+## should copy the type descriptor of another type. While similar to an
+## "alias", a TypeCopy doesn't redirect a name to another type, it copies the
+## entire type definition and assigns it to another type.
+##
+## The DSL defines a TypeCopy as `type NewThing CopiedThing`, where
+## "CopiedThing" refers to a `type` defined elsewhere in a schema and is not
+## one of TypeKind or an inline type descriptor (`{}`, `[]`, `&`).
+##
+type TypeCopy struct {
+	fromType TypeName
 }

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -46,7 +46,8 @@
 						"link": "TypeLink",
 						"union": "TypeUnion",
 						"struct": "TypeStruct",
-						"enum": "TypeEnum"
+						"enum": "TypeEnum",
+						"copy": "TypeCopy"
 					}
 				}
 			}
@@ -64,7 +65,8 @@
 				"link": null,
 				"union": null,
 				"struct": null,
-				"enum": null
+				"enum": null,
+				"copy": null
 			}
 		},
 		"RepresentationKind": {
@@ -537,6 +539,17 @@
 						"keyType": "String",
 						"valueType": "Null"
 					}
+				}
+			},
+			"representation": {
+				"map": {}
+			}
+		},
+		"TypeCopy": {
+			"kind": "struct",
+			"fields": {
+				"fromType": {
+					"type": "TypeName"
 				}
 			},
 			"representation": {


### PR DESCRIPTION
First go at defining a `copy` type. This might naively be thought of as an **alias** and it's what Filecoin is trying to do in https://github.com/filecoin-project/specs/blob/master/network-protocols.md:

```
type StorageDealResponse union {
    | UnknownParams
    | RejectedParams
    | AcceptedParams
    | StartedParams
    | StagedParams
...
} representation keyed
...
type RejectedParams struct {
    message optional String
    proposal &SignedStorageDealProposal
}
type AcceptedParams RejectedParams
type FailedParams RejectedParams
type StagedParams RejectedParams
...
```

So you get the same structure in memory but a different _thing_ (handle?) to assert against and you get more descriptive power in in your schemas as well as reducing duplication.

**BUT** this is not intended to be implemented as an alias, it's a copy in the macro sense. We are taking one type definition, changing the name and creating a new one with the same shape and representation. It's is described here as a short-hand for repeated definitions.

## JSON form

I've introduced a new schema kind of `"copy"` to store this in the JSON form. We want to retain the fact that it's a `copy` and only perform the copying when we implement a thing (codegen, validation, whatever)—we get to a type, find it's a `"copy"` and redirect to the `"fromType"` to get the definition body but with the original name. It would look like this:

```
  "Foo": {
    "kind": "copy",
    "fromType": "Bar"
  }
```

## DSL syntax

Regarding syntax, I think @warpfork originally proposed `type Foo = Bar`, and I'm sympathetic to the idea of introducing a delimiter to make it clear what's going on and avoid confusion with the other schema kinds that can go in that position with an empty definition (`bytes`, `string`, etc.). Here's some variations to consider:

* `type Foo Bar`
* `type Foo = Bar`
* `type Foo copy Bar`
* `type Foo <= Bar`