### PR TITLE
Add exploration report about using Serde for Rust IPLD

### DIFF
--- a/design/history/exploration-reports/2019.09-rust-serde.md
+++ b/design/history/exploration-reports/2019.09-rust-serde.md
@@ -1,0 +1,58 @@
+Using Serde for Rust IPLD
+=========================
+
+**Author**: Volker Mische ([@vmx])
+
+It sounds like a great idea using [Serde] as basis for Rust IPLD. It should be simply to put the [IPLD Data Model] on top of the [Serde Data Model]. So I was looking into implementing DagCbor on top of [serde_cbor].
+
+Missing CBOR tags support in serde_cbor
+---------------------------------------
+
+The blocking issue is that there's no CBOR tags support in serde_cbpr. [@dignifiedquire] did an implementation for tags support. I couldn't get it working (due to not being familiar with Serde yet) for deserializing things into custom types. The plan was to serialize CBOR tag 42 into a "CID struct". I looked for other formats that are hitting the same limitation in Serde.
+
+[msgpack] has the notion of [Extensions] and there's also an implemention for Serde ([msgpack-rust]) which even gained [extension support recently]. So I used that as a basis to create yet another implementation of CBOR tags support for serde_cbor ([#151]). If you want to learn more about this approach, checkout the discussions at [#529: Implementing custom type serializing].
+
+I'm happy with the result and finally have a way better understanding of Serde. I now also understand why merging a PR following that approach would be problematic. You could serialize and deserialize CBOR tags with it, but there won't be any interoperability with e.g. rust-msgpack. You couldn't simply have a single implementation of a CID type that would work with CBOR as well as with msgpack. Though, I've created a [prototype] that can serialize/deserialize the IPLD Date Model into CBOR using the patched serde_cbor.
+
+So what would be needed in order to have it properly work with Serde?
+
+
+Tags support in Serde
+---------------------
+
+There has been plenty of discussions ways in order to get tags support as needed by formats like CBOR or msgpack into Serde. Here I try to give a bit of that history and the summary.
+
+The starting point is [#163: CBOR support], where the author of serde_cbor asks if it would be possible to add a `visit_tag()` method to Serde to support the tags use case. Following this idea a [#301: WIP: Parsing and emitting tagged values] is opened which starts adding support for serializing and deserializing tags. The discussion is about types that tags need to support, CBOR Tags are integers, YAML tags are strings. And also about the problem of different tags for the same data type in different formats.
+
+There is no conclusion, but that issues is superseded by [#408: Add support for tagged values.], which contains a full implementation. It seems to solve the problem, but a discussion starts, whether there are better ways to implement tags. A proposed solution is to use [specialization].
+
+That idea is further pursued in [#455: Tagged values through specialization]. After some discussion it reaches the point where the specialization doesn't work. Bug [#38516: Specialization does not find the default impl] was opened almost 3 years ago, but didn't find any attention.
+
+
+Conclusion
+----------
+
+I still like the idea of being able to use Serde for the Rust IPLD work. The chances are high that there is already a parser for for the file format you want to use, you would just need to implement make sure IPLD Data Model types can be (de)serialized.
+
+But in order to make this happen, we need tag support within Serde. I will try to revive the idea outlined in [#408: Add support for tagged values.], Without tag support there's no real benefit of using Serde and we would be better off having specialized parsers for each format we want to support. The result would then probably resemble Serde, but less flexible and specific to the IPLD Data Model.
+
+
+[@vmx]: https://github.com/vmx/
+[Serde]: https://serde.rs/
+[IPLD Data Model]: https://github.com/ipld/specs/blob/67028313e0793d562d671a7fb4a030f471f90098/data-model-layer/data-model.md
+[Serde Data Model]: https://serde.rs/data-model.html
+[serde_cbor]: https://github.com/pyfisch/cbor
+[@dignifiedquire]: https://github.com/dignifiedquire/
+[msgpack]: https://msgpack.org/
+[msgpack-rust]: https://github.com/3Hren/msgpack-rust
+[Extensions]: https://github.com/msgpack/msgpack/blob/1e4fd94b90d38167b8b5a0ecf57f59b538669574/spec.md#extension-types
+[extension support recently]: https://github.com/3Hren/msgpack-rust/pull/216
+[#151]: https://github.com/pyfisch/cbor/pull/151
+[#529: Implementing custom type serializing]: https://github.com/serde-rs/serde/issues/529
+[prototype]: https://github.com/vmx/rust-ipld-dag-cbor
+[#163: CBOR support]: https://github.com/serde-rs/serde/issues/163
+[#301: WIP: Parsing and emitting tagged values]: https://github.com/serde-rs/serde/pull/301
+[#408: Add support for tagged values.]: https://github.com/serde-rs/serde/pull/408
+[specialization]: https://github.com/rust-lang/rust/issues/31844
+[#455: Tagged values through specialization]: https://github.com/serde-rs/serde/pull/455
+[#38516: Specialization does not find the default impl]: https://github.com/rust-lang/rust/issues/38516


### PR DESCRIPTION
These are my thoughts while trying to implement DagCbor for Rust.
The implementation prototype can be found at https://github.com/vmx/rust-ipld-dag-cbor
