### PR TITLE
Add DagPB spec

### DIFF
--- a/Codecs/DAG-PB.md
+++ b/Codecs/DAG-PB.md
@@ -32,7 +32,7 @@ message PBNode {
 ```
 
 The objects link names are specified in the 'Name' field of the PBLink object.
-All links in an object must either be blank or unique within the object.
+All link names in an object must either be blank or unique within the object.
 
 ## Pathing
 

--- a/Codecs/DAG-PB.md
+++ b/Codecs/DAG-PB.md
@@ -10,10 +10,10 @@ The DAG-PB IPLD format is a legacy format implemented with a single protobuf.
 // An IPFS MerkleDAG Link
 message PBLink {
 
-  // multihash of the target object
+  // binary CID (with no multibase prefix) of the target object
   optional bytes Hash = 1;
 
-  // utf string name. should be unique per object
+  // UTF-8 string name.
   optional string Name = 2;
 
   // cumulative size of target object
@@ -32,24 +32,69 @@ message PBNode {
 ```
 
 The objects link names are specified in the 'Name' field of the PBLink object.
-This is non-standard and means that the 'Tsize' attribute of a link, and
-neither the 'Data' field nor the 'Links' field of the PBNode are available
-through the ipld query language. 
+All links in an object must either be blank or unique within the object.
 
-## Link Format
+## Pathing
 
-In DagCBOR, links are encoded using the raw-binary (identity, NUL) multibase in a
-field with a byte-string type (major type 2), with the tag 42. They are then
-put in the 'Hash' field of a PBLink. All links from a DAG-PB object are
-specified in the 'Links' array.
+TODO: See https://github.com/ipld/specs/issues/55
+TODO: Also see https://github.com/ipfs/unixfs-v2/issues/24 (specifically: the "Revise History" option).
+
+Neither go-ipfs nor js-ipfs agree so we have some room here because we're going to break something.
+
+### Alternative: go-ipfs
+
+In go-ipfs, we resolve use link names directly in paths: `/$name1/$name2/...`.
+Neither the Data section nor the Links section/metadata are accessible through
+paths.
+
+It's also impossible to path through nodes that don't name their links.
+
+### Alternative: js-ipfs
+
+As far as I can tell, js-ipfs supports pathing both by name and by index with
+paths like: `/Links/$name/Hash/...` or `/Links/$idx/Hash`.
+
+### Alternative: Correct IPLD
+
+Based purely on the _structure_, we should only support pathing by index. That
+is, `/Links/$idx/Hash`.
+
+### Alternative: Transform
+
+We could implicitly transform the protobuf to some new structure in the IPLD data model.
+
+1. If the object has no links, the "links" section is "null".
+2. If the object has links with names, all links must have unique names so we can treat links as a map:
+
+```
+{
+  "Data": ...,
+  "Links": {
+    "$name": {"target": Qm..., "size": ...}
+  }
+}
+```
+
+3. If the object has links without names, we can pack them into an array:
+
+```
+{
+  "Data": ...,
+  "Links": [
+    {"target": Qm..., "size": ...}
+  ]
+}
+```
 
 ## Canonical DAG-PB
 
 Canonical DAG-PB must:
 
 1. Contain only the specified protobuf fields.
-2. Use standard protobuf encoding, except that the 'Links' field must be before
-   the 'Data' field in the encoding. This is due to a bug in the initial
-   protobuf encoder that was used in the first implementation of ipfs.
-3. Only use string map keys. Some implementations may not be able to
-   handle non-string keys.
+2. Use standard protobuf encoding, with the following field orders:
+  - PBNode: Links, Data
+  - PBLink: Hash, Name, Tsize
+
+Historical Note: The ordering (Links then Data) of the PBNode message is due to
+a bug in the initial protobuf encoder that was used in the first implementation
+of ipfs. Take care to maintain this ordering for full compatibility.

--- a/Codecs/DAG-PB.md
+++ b/Codecs/DAG-PB.md
@@ -1,0 +1,55 @@
+# [WIP] DagPB Spec
+
+DAG-PB does not support the full ["IPLD Data Model v1."](../IPLD-Data-Model-v1.md)
+
+## Format
+
+The DAG-PB IPLD format is a legacy format implemented with a single protobuf.
+
+```protobuf
+// An IPFS MerkleDAG Link
+message PBLink {
+
+  // multihash of the target object
+  optional bytes Hash = 1;
+
+  // utf string name. should be unique per object
+  optional string Name = 2;
+
+  // cumulative size of target object
+  optional uint64 Tsize = 3;
+}
+
+// An IPFS MerkleDAG Node
+message PBNode {
+
+  // refs to other objects
+  repeated PBLink Links = 2;
+
+  // opaque user data
+  optional bytes Data = 1;
+}
+```
+
+The objects link names are specified in the 'Name' field of the PBLink object.
+This is non-standard and means that the 'Tsize' attribute of a link, and
+neither the 'Data' field nor the 'Links' field of the PBNode are available
+through the ipld query language. 
+
+## Link Format
+
+In DagCBOR, links are encoded using the raw-binary (identity, NUL) multibase in a
+field with a byte-string type (major type 2), with the tag 42. They are then
+put in the 'Hash' field of a PBLink. All links from a DAG-PB object are
+specified in the 'Links' array.
+
+## Canonical DAG-PB
+
+Canonical DAG-PB must:
+
+1. Contain only the specified protobuf fields.
+2. Use standard protobuf encoding, except that the 'Links' field must be before
+   the 'Data' field in the encoding. This is due to a bug in the initial
+   protobuf encoder that was used in the first implementation of ipfs.
+3. Only use string map keys. Some implementations may not be able to
+   handle non-string keys.

--- a/Codecs/DAG-PB.md
+++ b/Codecs/DAG-PB.md
@@ -1,4 +1,4 @@
-# [WIP] DagPB Spec
+# DagPB Spec
 
 DagPB does not support the full ["IPLD Data Model v1."](../IPLD-Data-Model-v1.md)
 
@@ -36,55 +36,14 @@ All link names in an object must either be blank or unique within the object.
 
 ## Pathing
 
-TODO: See https://github.com/ipld/specs/issues/55
-TODO: Also see https://github.com/ipfs/unixfs-v2/issues/24 (specifically: the "Revise History" option).
+There is some overlap between the Go and JavaScript implementation of DagPB. Both support pathing with link names: `/<name1>/<name2>/…`.
 
-Neither go-ipfs nor js-ipfs agree so we have some room here because we're going to break something.
+In Go, this is the only way, which implies that is is impossible to path through nodes that don't name their links. Also neither the Data section nor the Links section/metadata are accessible through paths.
 
-### Alternative: go-ipfs
+In the JavaScript implementation, there is an additional way to path through the data. It's based purely on the structure of object, i.e. `/Links/<index>/Hash/…`. This way you have direct access to the `Data`, `Links`, and `size` fields, e.g. `/Links/<index>/Hash/Data`.
 
-In go-ipfs, we resolve use link names directly in paths: `/$name1/$name2/...`.
-Neither the Data section nor the Links section/metadata are accessible through
-paths.
+These two ways of pathing can be combined, so you can access e.g. the `Data` field of a named link via `/<name/Data`. You can also use both approaches within a single path, e.g. `/<name1>/Links/0/Hash/Data` or `/Links/<index>/Hash/<name>/Data`. When using the DAG API in js-ipfs, then the pathing over the structure has precedence, so you won't be able to use named pathing on a named link called `Links`, you would need to use the index of the link instead.
 
-It's also impossible to path through nodes that don't name their links.
-
-### Alternative: js-ipfs
-
-As far as I can tell, js-ipfs supports pathing both by name and by index with
-paths like: `/Links/$name/Hash/...` or `/Links/$idx/Hash`.
-
-### Alternative: Correct IPLD
-
-Based purely on the _structure_, we should only support pathing by index. That
-is, `/Links/$idx/Hash`.
-
-### Alternative: Transform
-
-We could implicitly transform the protobuf to some new structure in the IPLD data model.
-
-1. If the object has no links, the "links" section is "null".
-2. If the object has links with names, all links must have unique names so we can treat links as a map:
-
-```
-{
-  "Data": ...,
-  "Links": {
-    "$name": {"target": Qm..., "size": ...}
-  }
-}
-```
-
-3. If the object has links without names, we can pack them into an array:
-
-```
-{
-  "Data": ...,
-  "Links": [
-    {"target": Qm..., "size": ...}
-  ]
-}
-```
 
 ## Canonical DagPB
 

--- a/Codecs/DAG-PB.md
+++ b/Codecs/DAG-PB.md
@@ -1,10 +1,10 @@
 # [WIP] DagPB Spec
 
-DAG-PB does not support the full ["IPLD Data Model v1."](../IPLD-Data-Model-v1.md)
+DagPB does not support the full ["IPLD Data Model v1."](../IPLD-Data-Model-v1.md)
 
 ## Format
 
-The DAG-PB IPLD format is a legacy format implemented with a single protobuf.
+The DagPB IPLD format is a legacy format implemented with a single protobuf.
 
 ```protobuf
 // An IPFS MerkleDAG Link
@@ -86,9 +86,9 @@ We could implicitly transform the protobuf to some new structure in the IPLD dat
 }
 ```
 
-## Canonical DAG-PB
+## Canonical DagPB
 
-Canonical DAG-PB must:
+Canonical DagPB must:
 
 1. Contain only the specified protobuf fields.
 2. Use standard protobuf encoding, with the following field orders:

--- a/block-layer/codecs/dag-pb.md
+++ b/block-layer/codecs/dag-pb.md
@@ -1,10 +1,12 @@
 # DagPB Spec
 
+**Status: Descriptive - Draft**
+
 DagPB does not support the full ["IPLD Data Model."](../../data-model-layer/data-model.md)
 
 ## Format
 
-The DagPB IPLD format is a legacy format implemented with a single protobuf.
+The DagPB IPLD format is a format implemented with a single protobuf.
 
 ```protobuf
 // An IPFS MerkleDAG Link
@@ -32,11 +34,13 @@ message PBNode {
 ```
 
 The objects link names are specified in the 'Name' field of the PBLink object.
-All link names in an object must either be blank or unique within the object.
+All link names in an object must either be omitted or unique within the object.
 
 ## Pathing
 
-There is some overlap between the Go and JavaScript implementation of DagPB. Both support pathing with link names: `/<name1>/<name2>/…`.
+The pathing is currently different between implementations. Please see [issue #55] for more information about the harmonization effort. This section describes the current implementations as of September 2019.
+
+The Go and JavaScript implementation both support pathing with link names: `/<name1>/<name2>/…`.
 
 In Go, this is the only way, which implies that is is impossible to path through nodes that don't name their links. Also neither the Data section nor the Links section/metadata are accessible through paths.
 
@@ -57,3 +61,5 @@ Canonical DagPB must:
 Historical Note: The ordering (Links then Data) of the PBNode message is due to
 a bug in the initial protobuf encoder that was used in the first implementation
 of ipfs. Take care to maintain this ordering for full compatibility.
+
+[issue #55]: https://github.com/ipld/specs/issues/55

--- a/block-layer/codecs/dag-pb.md
+++ b/block-layer/codecs/dag-pb.md
@@ -1,6 +1,6 @@
 # DagPB Spec
 
-DagPB does not support the full ["IPLD Data Model v1."](../IPLD-Data-Model-v1.md)
+DagPB does not support the full ["IPLD Data Model."](../../data-model-layer/data-model.md)
 
 ## Format
 


### PR DESCRIPTION
This PR combines #114 and #115 and addresses all code review comments from there.

I then changed the section about pathing to describe the current state in the Go and JS implementations. As this is a descriptive spec, I find this a sensible approach.

Of course it would be desirable to harmonize how pathing works between implementations, but that hasn't happened for a long time and I don't see this happening soon. Hence I find having the current state document is better than keeping discussing it without taking action.