### PR TITLE
Graphsync: Make Extra A Map And Clarify Its Role

### DIFF
--- a/block-layer/graphsync/graphsync.md
+++ b/block-layer/graphsync/graphsync.md
@@ -66,16 +66,16 @@ message GraphsyncMessage {
     int32 id = 1;       // unique id set on the requester side
     bytes root = 2;     // a CID for the root node in the query
     bytes selector = 3; // ipld selector to retrieve
-    bytes extra = 4;    // aux information. useful for other protocols
+    map<string, bytes> extra = 4; // side channel information
     int32 priority = 5;	// the priority (normalized). default to 1
     bool  cancel = 6;   // whether this cancels a request
   }
 
   message Response {
-    int32 id = 1;     // the request id
-    int32 status = 2; // a status code.
+    int32 id = 1;       // the request id
+    int32 status = 2;   // a status code.
     bytes metadata = 3; // metadata about response
-    bytes extra = 4;
+    map<string, bytes> extra = 4;    // side channel information
   }
 
   message Block {
@@ -121,6 +121,12 @@ type LinkMetadata struct {
 
 type ResponseMetadata [LinkMetadata]
 ```
+
+### Side Channel Information
+
+The 'extra' field on both a graphsync request and a graphsync response is used to communicate side channel information that other protocols using graphsync may need to determine how to service a graphsync request. 
+
+The extra field is a map type, where the keys are protocol names, and the values are a data relevant to that protocol
 
 ### Response Status Codes
 


### PR DESCRIPTION
# Goals

Support multiple forms of side channel infromation, clarify the role of an extra field

# Implementation

Make extra a map field and document it's use.

Per discussions in https://github.com/ipld/specs/pull/111 -- we may want to pass multiple types of side channel information, and it would be useful for graphsync consumers to be able to work with them individually.

Per that PR, we added `metadata`, which I don't feel is a "side channel" piece of information because it's vital to writing a performant GraphSync client. 

At the same time, I agree with https://github.com/ipld/specs/pull/111#issuecomment-489217279 -- extra should be a map similar to TLS extensions, which you can read all of or ignore

# For Discussion

Extra could also remain simply a "bytes" type an be a serialized CBOR encoded IPLD Map. However, it feels more performant to just decode the mapping from protobuf, after which extension implementations can deserialize their specific data however they want, and if it's in IPLD CBOR, use a decoder optimized for their type of information.