### PR TITLE
Graphsync: Extensions

### DIFF
--- a/block-layer/graphsync/graphsync.md
+++ b/block-layer/graphsync/graphsync.md
@@ -66,16 +66,16 @@ message GraphsyncMessage {
     int32 id = 1;       // unique id set on the requester side
     bytes root = 2;     // a CID for the root node in the query
     bytes selector = 3; // ipld selector to retrieve
-    bytes extra = 4;    // aux information. useful for other protocols
+    map<string, bytes> extra = 4;    // side channel information for other protocols
     int32 priority = 5;	// the priority (normalized). default to 1
     bool  cancel = 6;   // whether this cancels a request
   }
 
   message Response {
-    int32 id = 1;     // the request id
-    int32 status = 2; // a status code.
+    int32 id = 1;       // the request id
+    int32 status = 2;   // a status code.
     bytes metadata = 3; // metadata about response
-    bytes extra = 4;
+    map<string, bytes> extra = 4;    // side channel information for other protocols
   }
 
   message Block {
@@ -121,6 +121,12 @@ type LinkMetadata struct {
 
 type ResponseMetadata [LinkMetadata]
 ```
+
+### Side Channel Information
+
+The 'extra' field on both a graphsync request and a graphsync response is used to communicate side channel information that other protocols using graphsync may need to determine how to service a graphsync request. 
+
+The extra field is a map type, where the keys are protocol names, and the values are a data relevant to that protocol
 
 ### Response Status Codes
 

--- a/block-layer/graphsync/graphsync.md
+++ b/block-layer/graphsync/graphsync.md
@@ -74,7 +74,8 @@ message GraphsyncMessage {
   message Response {
     int32 id = 1;     // the request id
     int32 status = 2; // a status code.
-    bytes extra = 3;
+    bytes metadata = 3; // metadata about response
+    bytes extra = 4;
   }
 
   message Block {
@@ -90,6 +91,37 @@ message GraphsyncMessage {
 }
 ```
 
+### Response Metadata
+
+Response metadata provides information about the response to help the requestor more efficiently verify the blocks sent back from the responder are valid for the requested IPLD selector. It contains information about the CIDs the responder traversed, in order, during the course of performing the selector query and whether or not the corresponding block was present in its local block store.
+
+It is an IPLD node of the format:
+
+```json
+[
+  {
+    "link": "cidabcdef",
+    "blockPresent": true
+  },
+  {
+    "link": "abcdedf443",
+    "blockPresent": false
+  },
+  ...
+]
+```
+
+or in IPLD Schema:
+
+```ipldsch
+type LinkMetadata struct {
+  link Cid
+  blockPresent Bool
+}
+
+type ResponseMetadata [LinkMetadata]
+```
+
 ### Response Status Codes
 
 ```
@@ -98,7 +130,7 @@ message GraphsyncMessage {
 11   Additional Peers. PeerIDs in extra.
 12   Not enough vespene gas ($)
 13   Other Protocol - info in extra.
-14   Partial Response w/ metadata, may include blocks, metadata in extra
+14   Partial Response w/ metadata, may include blocks
 
 # success - terminal
 20   Request Completed, full content.

--- a/block-layer/graphsync/graphsync.md
+++ b/block-layer/graphsync/graphsync.md
@@ -66,16 +66,17 @@ message GraphsyncMessage {
     int32 id = 1;       // unique id set on the requester side
     bytes root = 2;     // a CID for the root node in the query
     bytes selector = 3; // ipld selector to retrieve
-    map<string, bytes> extra = 4;    // side channel information for other protocols
+    map<string, bytes> extra = 4; // side channel information
     int32 priority = 5;	// the priority (normalized). default to 1
     bool  cancel = 6;   // whether this cancels a request
+    repeated bytes excluded_cids = 7; // cids not to send blocks for
   }
 
   message Response {
     int32 id = 1;       // the request id
     int32 status = 2;   // a status code.
     bytes metadata = 3; // metadata about response
-    map<string, bytes> extra = 4;    // side channel information for other protocols
+    map<string, bytes> extra = 4;    // side channel information
   }
 
   message Block {
@@ -90,6 +91,15 @@ message GraphsyncMessage {
   repeated Block    data      = 4; // Blocks related to the responses
 }
 ```
+
+### Excluded CIDs
+
+Often a node may know ahead of time that it has some of the blocks needed to match a selector query in its local store already. Some reasons this might occur include:
+
+- a previous request was interrupted
+- a previous request for a subset of the requested selector was already completed
+
+A node can pass additional information about CIDs it already has to the responder node, which the responder node MAY choose not to send in its response.
 
 ### Response Metadata
 

--- a/block-layer/graphsync/graphsync.md
+++ b/block-layer/graphsync/graphsync.md
@@ -66,17 +66,15 @@ message GraphsyncMessage {
     int32 id = 1;       // unique id set on the requester side
     bytes root = 2;     // a CID for the root node in the query
     bytes selector = 3; // ipld selector to retrieve
-    map<string, bytes> extra = 4; // side channel information
+    map<string, bytes> extensions = 4; // side channel information
     int32 priority = 5;	// the priority (normalized). default to 1
     bool  cancel = 6;   // whether this cancels a request
-    repeated bytes excluded_cids = 7; // cids not to send blocks for
   }
 
   message Response {
-    int32 id = 1;       // the request id
-    int32 status = 2;   // a status code.
-    bytes metadata = 3; // metadata about response
-    map<string, bytes> extra = 4;    // side channel information
+    int32 id = 1;     // the request id
+    int32 status = 2; // a status code.
+    map<string, bytes> extensions = 3;    // side channel information
   }
 
   message Block {
@@ -92,51 +90,14 @@ message GraphsyncMessage {
 }
 ```
 
-### Excluded CIDs
 
-Often a node may know ahead of time that it has some of the blocks needed to match a selector query in its local store already. Some reasons this might occur include:
+### Extensions
 
-- a previous request was interrupted
-- a previous request for a subset of the requested selector was already completed
+The Graphsync protocol is extensible. A graphsync request and a graphsync response contain an `extensions` field, which is a map type. Each key of the extensions field specifies the name of the extension, while the value is data (serialized as bytes) relevant to that extension.
 
-A node can pass additional information about CIDs it already has to the responder node, which the responder node MAY choose not to send in its response.
+Extensions help make Graphsync operate more efficiently, or provide a mechanism for exchanging side channel information for other protocols. An implementation can choose to support one or more extensions, but it does not have to.
 
-### Response Metadata
-
-Response metadata provides information about the response to help the requestor more efficiently verify the blocks sent back from the responder are valid for the requested IPLD selector. It contains information about the CIDs the responder traversed, in order, during the course of performing the selector query and whether or not the corresponding block was present in its local block store.
-
-It is an IPLD node of the format:
-
-```json
-[
-  {
-    "link": "cidabcdef",
-    "blockPresent": true
-  },
-  {
-    "link": "abcdedf443",
-    "blockPresent": false
-  },
-  ...
-]
-```
-
-or in IPLD Schema:
-
-```ipldsch
-type LinkMetadata struct {
-  link Cid
-  blockPresent Bool
-}
-
-type ResponseMetadata [LinkMetadata]
-```
-
-### Side Channel Information
-
-The 'extra' field on both a graphsync request and a graphsync response is used to communicate side channel information that other protocols using graphsync may need to determine how to service a graphsync request. 
-
-The extra field is a map type, where the keys are protocol names, and the values are a data relevant to that protocol
+A list of well known extensions is found [here](./known_extensions.md)
 
 ### Response Status Codes
 

--- a/block-layer/graphsync/known_extensions.md
+++ b/block-layer/graphsync/known_extensions.md
@@ -1,8 +1,8 @@
 # Graphsync: Known Extensions
 
-### Excluded CIDs
+### Do Not Send CIDs
 
-Extension Name: `graphsync/exclude-cids`
+Extension Name: `graphsync/do-not-send-cids`
 
 What it does:
 
@@ -18,10 +18,10 @@ When a requestor sends a request, it should send a CBOR encoded IPLD Node that i
 The IPLD schema is as follows:
 
 ```ipldsch
-type ExcludedCids [Cid]
+type DoNotSendCids [Cid]
 ```
 
-The responder node, if it supports the extension, will not send those blocks back in the response. It does not send a value back in the response for this extension.
+The responder node will execute the selector query as it would normally. However, if it supports the extension, when the selector query passes over any blocks that have a cid from the DoNotSend list, the responder will not send that block back, knowing ahead of time the requestor already has it. The responder does not send a value back in the response for this extension.
 
 ### Response Metadata
 
@@ -29,7 +29,7 @@ Extension Name: `graphsync/response-metadata`
 
 What it does:
 
-Response metadata provides information about the response to help the requestor more efficiently verify the blocks sent back from the responder are valid for the requested IPLD selector. It contains information about the CIDs the responder traversed, in order, during the course of performing the selector query and whether or not the corresponding block was present in its local block store.
+Response metadata provides information about the response to help the requestor more efficiently verify that the blocks sent back from the responder are valid for the requested IPLD selector. It contains information about the CIDs the responder traversed, in order, during the course of performing the selector query, and whether or not the corresponding block was present in its local block store. Telling the requestor immediately that the query passed over a block the responder did not have allows the requestor to advance its local query, and return a seperate error for that particular block.
 
 How it works:
 

--- a/block-layer/graphsync/known_extensions.md
+++ b/block-layer/graphsync/known_extensions.md
@@ -1,0 +1,63 @@
+# Graphsync: Known Extensions
+
+### Excluded CIDs
+
+Extension Name: `graphsync/exclude-cids`
+
+What it does:
+
+Often a node may know ahead of time that it has some of the blocks needed to match a selector query in its local store already. Some reasons this might occur include:
+
+- a previous request was interrupted
+- a previous request for a subset of the requested selector was already completed
+
+How it works:
+
+When a requestor sends a request, it should send a CBOR encoded IPLD Node that is a list of CIDs it already has as the value for this extension.
+
+The IPLD schema is as follows:
+
+```ipldsch
+type ExcludedCids [Cid]
+```
+
+The responder node, if it supports the extension, will not send those blocks back in the response. It does not send a value back in the response for this extension.
+
+### Response Metadata
+
+Extension Name: `graphsync/response-metadata`
+
+What it does:
+
+Response metadata provides information about the response to help the requestor more efficiently verify the blocks sent back from the responder are valid for the requested IPLD selector. It contains information about the CIDs the responder traversed, in order, during the course of performing the selector query and whether or not the corresponding block was present in its local block store.
+
+How it works:
+
+When a requestor node sends a request, it should include the "graphsync/response-metadata" key with an CBOR-encoded IPLD encoded boolean value of true to request metadata.
+
+When the responder sends responses, it should include the key with a CBOR-encoded IPLD node of the format:
+
+```json
+[
+  {
+    "link": "cidabcdef",
+    "blockPresent": true
+  },
+  {
+    "link": "abcdedf443",
+    "blockPresent": false
+  },
+  ...
+]
+```
+
+or in IPLD Schema:
+
+```ipldsch
+type LinkMetadata struct {
+  link Cid
+  blockPresent Bool
+}
+
+type ResponseMetadata [LinkMetadata]
+```


### PR DESCRIPTION
# Goals

Support several additions to the Graphsync Protocol without constantly iterating on spec

# Implementation

- Consolidates #204 #111 into a single proposal for Graphsync Extensions that operate similar to TLS Extensions
- Adds a list of well known extensions:
1. The previous metadata proposal from #111 
2. A proposal for sending excluded CIDs with the request that the responder could use to narrow down the blocks it sends back (by not including any blocks that match the CIDs in the set.