### PR TITLE
fix: minor schema-schema json formatting mistakes

### DIFF
--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -3,6 +3,7 @@
 ## Yes, it's self-describing! :)
 ## -----
 
+##
 ## Type names are a simple alias of string.
 ##
 ## There are some additional rules that should be applied:
@@ -222,12 +223,16 @@ type TypeFloat struct {}
 ## TypeMap describes a key-value map.
 ## The keys and values of the map have some specific type of their own.
 ##
+## A constraint on keyType is that the referenced type must have a string
+## representation kind. The IPLD Data Model only allows for string keys on maps,
+## so this constraint is imposed here.
+##
 type TypeMap struct {
-	keyType TypeName # additionally, the referenced type must be reprkind==string.
+	keyType TypeName
 	valueType TypeTerm
 	valueNullable Bool (implicit "false")
 	representation MapRepresentation
-} representation map
+}
 
 ## MapRepresentation describes how a map type should be mapped onto
 ## its IPLD Data Model representation.  By default a map is a map in the
@@ -285,7 +290,7 @@ type TypeList struct {
 	valueType TypeTerm
 	valueNullable Bool (implicit "false")
 	representation ListRepresentation
-} representation map
+}
 
 ## ListRepresentation describes how a map type should be mapped onto
 ## its IPLD Data Model representation.  By default a list is a list in the
@@ -490,7 +495,7 @@ type StructField struct {
 	type TypeTerm
 	optional Bool (implicit "false")
 	nullable Bool (implicit "false")
-} representation map
+}
 
 ## TypeTerm is a union of either TypeName or an InlineDefn. th It's used for the
 ## value type in the recursive types (maps, lists, and the fields of structs),
@@ -650,7 +655,7 @@ type StructRepresentation_ListPairs struct {}
 ## all int values are required.
 ##
 type TypeEnum struct {
-  members {EnumValue:Null}
+	members {EnumValue:Null}
 	representation EnumRepresentation
 }
 

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -543,7 +543,7 @@
 						"kind": "map",
 						"keyType": "EnumValue",
 						"valueType": "Null"
-					 }
+					}
 				},
 				"representation": {
 					"type": "EnumRepresentation"
@@ -553,6 +553,9 @@
 				"map": {}
 			}
 		},
+		"EnumValue": {
+			"kind": "string"
+		},
 		"EnumRepresentation": {
 			"kind": "union",
 			"representation": {
@@ -561,9 +564,6 @@
 					"int": "EnumRepresentation_Int"
 				}
 			}
-		},
-		"EnumValue": {
-			"kind": "string"
 		},
 		"EnumRepresentation_String": {
 			"kind": "map",


### PR DESCRIPTION
was manually edited prior to tooling implementation, this is with tooling so it has proper ordering and spacing

seems trivial, I know, but I'm using the raw text of this to test my jsonifiers