### PR TITLE
RFC: Support recursive selectors that have no maxDepth for full DAG traversal

### DIFF
--- a/selectors/selectors.md
+++ b/selectors/selectors.md
@@ -117,9 +117,14 @@ type ExploreRange struct {
 ## Be careful when using ExploreRecursive with a large maxDepth parameter;
 ## it can easily cause very large traversals (especially if used in combination
 ## with selectors like ExploreAll inside the sequence).
+##
+## If no maxDepth is specified, recursion will continue as long as
+## the selection continues to traverse ExploreRecursiveEdge - be very careful
+## with this
+
 type ExploreRecursive struct {
 	sequence Selector (rename ":>")
-	maxDepth Int (rename "d")
+	maxDepth optional Int (rename "d")
 	stopAt optional Condition (rename "!") # if a node matches, we won't match it nor explore its children.
 }
 

--- a/selectors/selectors.md
+++ b/selectors/selectors.md
@@ -100,8 +100,8 @@ type ExploreRange struct {
 ## In implementation, whenever evaluation reaches an ExploreRecursiveEdge marker
 ## in the recursion sequence's Selector tree, the implementation logically
 ## produces another new Selector which is a copy of the original
-## ExploreRecursive selector, but with a decremented maxDepth parameter, and
-## continues evaluation thusly.
+## ExploreRecursive selector, but with a decremented depth parameter for limit
+## (if limit is of type depth), and continues evaluation thusly.
 ##
 ## It is not valid for an ExploreRecursive selector's sequence to contain
 ## no instances of ExploreRecursiveEdge; it *is* valid for it to contain
@@ -114,19 +114,28 @@ type ExploreRange struct {
 ## be thought of like the 'continue' statement, or end of a for-loop body;
 ## it is *not* a 'goto' statement).
 ##
-## Be careful when using ExploreRecursive with a large maxDepth parameter;
+## Be careful when using ExploreRecursive with a large depth limit parameter;
 ## it can easily cause very large traversals (especially if used in combination
 ## with selectors like ExploreAll inside the sequence).
 ##
-## If no maxDepth is specified, it is up to the implementation library using 
-## selectors to identify an appropriate max depth as neccesary so that recursion
-## is not infinite
+## limit is a union type -- it can have an integer depth value (key "depth") or
+## no value (key "none"). If limit has no value it is up to the 
+## implementation library using selectors to identify an appropriate max depth
+## as neccesary so that recursion is not infinite
 
 type ExploreRecursive struct {
 	sequence Selector (rename ":>")
-	maxDepth optional Int (rename "d")
+	limit RecursionLimit (rename "l")
 	stopAt optional Condition (rename "!") # if a node matches, we won't match it nor explore its children.
 }
+
+type RecursionLimit union {
+	| RecursionLimit_None "none"
+	| RecursionLimit_Depth "depth"
+} representation keyed
+
+type RecursionLimit_None struct {}
+type RecursionLimit_Depth int
 
 ## ExploreRecursiveEdge is a special sentinel value which is used to mark
 ## the end of a sequence started by an ExploreRecursive selector: the recursion

--- a/selectors/selectors.md
+++ b/selectors/selectors.md
@@ -118,9 +118,9 @@ type ExploreRange struct {
 ## it can easily cause very large traversals (especially if used in combination
 ## with selectors like ExploreAll inside the sequence).
 ##
-## If no maxDepth is specified, recursion will continue as long as
-## the selection continues to traverse ExploreRecursiveEdge - be very careful
-## with this
+## If no maxDepth is specified, it is up to the implementation library using 
+## selectors to identify an appropriate max depth as neccesary so that recursion
+## is not infinite
 
 type ExploreRecursive struct {
 	sequence Selector (rename ":>")


### PR DESCRIPTION
# Goal

In several discussions surrounding Graphsync, a common assumption is that you can ask Graphsync to "sync a DAG" -- as in, starting at a CID, traverse the node and anything under it, sending back all blocks that are linked from the root CID. 

However, we don't currently have a selector that actually does this. We can approximate the behavior with a selector that looks like this:

```ipldsch
ExploreRecursive {
   maxDepth 9999999
   sequence {
      ExploreAll {
          next {
             ExploreRecursiveEdge {}
          }
      }
   }
```

For those unfamiliar with the Selector DSL, this means "for each node, traverse all its fields, and then recursively apply the same traversal to the fields, up to a depth level of 9999999 (or other appropriately large number)"

The issue here is that we have to awkwardly supply a constant number of recursions and hope the DAG we're traversing isn't large enough to exceed maxDepth.

# Implementation

The proposal simply would make max depth optional, in which case recursion would continue until it stopped encountering ExploreRecursiveEdge{}. (this would normally occur cause it ran out of feels that could be traversed -- only map types and list types can be traversed (plus links, trasparently), so it would therefore stop as long as the dag had limits to it.

# For Discussion

There are various potential issues with working with selectors with high-recursion maxDepths or no maxDepth at all.

1. Memory requirements - currently selector implementation implementation uses a stack for recursive selectors, which means potential memory issues if recursive continues infinitely

2. Potential DOS vectors in an untrusted network context like GraphSync - if there is no limit, multiple requests for a very large DAG could potentially take down a node

At the same time, there is a convincing argument that all of these concerns should be left to implementation, NOT what is permissible a the selector itself.

For example, on the network DOS level, it seems particularly important to allow a Graphsync node to limit what selectors are accepted beyond the overall selector specification significantly (for example, a node might only accept maxDepth < 100).

Similarly a selector traversal algorithm should probably contain logic to prevent a traversal likely to case an out of memory limit.

In any case, there is a common user expectation that a selector + graphsync can be used to quickly "sync a dag" and therefore, it seems prudent to insure there is a good story there. And while "sync a dag" without limits might not make sense in an untrusted context like the IPFS network, it might make sense in several situations where one wants to do point-to-point transmission between two peers that have reason to trust each other (such as a pre-agreed upon transfer).

This PR is meant just to start a discussion where several interested parties can comment. I've somewhat paraphrased things others have told me for or against something like this, so feel free to explain your position in more detail since I am probably not doing a great job doing so.

Also, it is perhaps a start off for a larger discussion of "what kinds of concerns should determine what goes in the specification of selectors vs what is a concern of implementation or other libraries that use them"
@warpfork @anorth @jbenet @whyrusleeping 