### PR TITLE
schemas: rootType for advanced data layouts

### DIFF
--- a/schemas/advanced-layouts.md
+++ b/schemas/advanced-layouts.md
@@ -37,3 +37,40 @@ type MyMap { String : &Any } representation advanced ShardedMap
 ```
 
 From this usage, we may infer that `ShardedMap` can (1) present a familiar `map` kind interface and (2) store `link`s as values (with no specific "expectedType"), referenced by standard data model `string`s. Other operating modes for `ShardedMap` may also be possible (it may be able to store other value kinds, or it may even be able to act as a `bytes` kind in spite of its name!).
+
+## Defining underlying data layout
+
+When defining an `advanced` data layout, we can also describe the underlying data behind it with a `rootType` which may be as complex as necessary.
+
+```ipldsch
+type ROT13EncodedString string
+
+advanced ROT13 {
+  rootType ROT13EncodedString
+}
+
+type MyString string representation advanced ROT13
+```
+
+In this instance, we describe a data structure `MyString` which acts as a `string`, is serialized as a `string` but encoded and decoded through a programatic interface called `ROT13`.
+
+A more advanced example of a `rootType` could include complex, nested data structures:
+
+```ipldsch
+advanced HashMap {
+  rootType HashMapRoot
+}
+
+type HashMapRoot struct {
+  hashAlg String
+  bucketSize Int
+  map Bytes
+  data [ Element ]
+}
+
+# .. additional type definitions to for `Element` and other types
+
+type MyMap { String : &Any } representation advanced HashMap
+```
+
+Our `HashMapRoot` contains internal details needed to implement the `HashMap` but these are opaque to the consumer of our advanced data layout. `HashMap` presents as standard `map` kind when consumed in `MyMap`.

--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -177,7 +177,12 @@ type AnyScalar union {
 ## to make a connection with the algorithm/logic behind this ADL. Future
 ## iterations may formalize this connection by some other means.
 ##
-type AdvancedDataLayout struct {}
+## When specifying a `rootType`, we indicate that the serialized form is
+## structured according to the TypeTerm provided.
+##
+type AdvancedDataLayout struct {
+  rootType optional TypeTerm
+}
 
 ## TypeBool describes a simple boolean type.
 ## It has no details.

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -101,7 +101,12 @@
 		},
 		"AdvancedDataLayout": {
 			"kind": "struct",
-			"fields": {},
+			"fields": {
+				"rootType": {
+					"type": "TypeTerm",
+					"optional": true
+				}
+			},
 			"representation": {
 				"map": {}
 			}
@@ -543,7 +548,7 @@
 						"kind": "map",
 						"keyType": "EnumValue",
 						"valueType": "Null"
-					 }
+					}
 				},
 				"representation": {
 					"type": "EnumRepresentation"
@@ -553,6 +558,9 @@
 				"map": {}
 			}
 		},
+		"EnumValue": {
+			"kind": "string"
+		},
 		"EnumRepresentation": {
 			"kind": "union",
 			"representation": {
@@ -561,9 +569,6 @@
 					"int": "EnumRepresentation_Int"
 				}
 			}
-		},
-		"EnumValue": {
-			"kind": "string"
 		},
 		"EnumRepresentation_String": {
 			"kind": "map",


### PR DESCRIPTION
* currently `optional`, maybe it shouldn't be
* when omitted, should it be `advanced Foo {}` rather than the current `advanced Foo`?

@mikeal has good example of how this is useful, when you have an integrated set of components that included `advanced` layouts, without `rootType` they don't connect cleanly. It's still unclear exactly what you'd want when you're consuming someone else's ADL and don't want to care about the internal pieces of it (our HashMap or Vector for instance). And, do I _need_ a schema and to use our tooling to produce publish an ADL? Can't I make one entirely programmatic that you could pick off the shelf?

Anyway, `optional` gives us some wriggle room while we figure all of this stuff out.