### PR TITLE
[WIP] UnixFSv2 Schema

### DIFF
--- a/data-structures/unixfsv2.md
+++ b/data-structures/unixfsv2.md
@@ -1,0 +1,68 @@
+# UnixFSv2 Schema
+
+This doc contains the File and Directory schemas for UnixFSv2.
+
+This schema depends on some Advanced Layouts and types defined
+in other schemas:
+
+* [Data](https://github.com/ipld/specs/pull/211)
+* [Hashmap](https://github.com/ipld/specs/blob/master/data-structures/hashmap.md)
+
+```sh
+type DirData union {
+  | EntryMap "map"
+  | Hamt "hamt"
+} representation keyed
+
+type EntryMap {String:EntryUnion}
+
+type EntryUnion union {
+  | File "file"
+  | &File "fileLink"
+  | Directory "dir"
+  | &Directory "dirLink"
+} representation keyed
+
+# WIP: Hashmap does not yet have an advanced layout definition.
+# type Hamt {String:FileUnion}<HAMT>
+
+# advanced HAMT {
+#   implementation "IPLD/experimental/HAMT/v1"
+# }
+
+type Directory struct {
+  name optional String
+  size optional Int
+  data DirData
+}
+
+type Permissions struct {
+  uid Int
+  gid Int
+  posix Int # The standard 0777 bitpacking masks
+
+  sticky Bool (implicit "false")
+  setuid Bool (implicit "false")
+  setgid Bool (implicit "false")
+}
+
+type Attributes struct {
+  mtime optional Int
+  atime optional Int
+  ctime optional Int
+  mtime64 optional Int
+  atime64 optional Int
+  ctime64 optional Int
+
+  permissions optional Permissions
+
+  devMajor optional Int
+  devMinor optional Int
+}
+
+type File struct {
+  name optional String
+  data optional Data
+  size optional Int
+}
+```


### PR DESCRIPTION
This is the schema that is currently implemented in [`js-unixfsv2`](https://github.com/ipld/js-unixfsv2).

A lot of kinks in the structure of the file, directory and data layout have had the kinks worked out in the process of implementation. However, the file metadata hasn’t been used yet and the tradeoffs we’ll need to discuss about that aren’t the kinds of things implementation along will resolve and we should use this PR to work them out.