### PR TITLE
feat: require deterministic map serialization

### DIFF
--- a/data-model-layer/data-model.md
+++ b/data-model-layer/data-model.md
@@ -115,7 +115,7 @@ Map is a recursive kind.
 Values in maps are accessed by their "key".  Maps can also be iterated over,
 yielding key+value pairs.
 
-**Maps must be serialized in a deterministic way (key sorting should be consistent regardless of insertion order or language specific sorting).** The sorting is not defined by the data model, each codec should find the best sorting algorithm, but the sorting must be consitent between languages and is most often implemented as additional code during serialization since most formats do not already have deterministic maps.
+Maps must be serialized in a deterministic way (key sorting should be consistent regardless of insertion order or language specific sorting). The sorting is not defined by the data model, each codec should find the best sorting algorithm, but the sorting must be consitent between languages and is most often implemented as additional code during serialization since most formats do not already have deterministic maps.
 
 #### Link kind
 

--- a/data-model-layer/data-model.md
+++ b/data-model-layer/data-model.md
@@ -115,6 +115,8 @@ Map is a recursive kind.
 Values in maps are accessed by their "key".  Maps can also be iterated over,
 yielding key+value pairs.
 
+**Maps must be serialized in a deterministic way (key sorting should be consistent regardless of insertion order or language specific sorting).** The sorting is not defined by the data model, each codec should find the best sorting algorithm, but the sorting must be consitent between languages and is most often implemented as additional code during serialization since most formats do not already have deterministic maps.
+
 #### Link kind
 
 A link represents a link to another IPLD Block. The link reference

--- a/data-model-layer/data-model.md
+++ b/data-model-layer/data-model.md
@@ -115,7 +115,7 @@ Map is a recursive kind.
 Values in maps are accessed by their "key".  Maps can also be iterated over,
 yielding key+value pairs.
 
-Maps must be serialized in a deterministic way (key sorting should be consistent regardless of insertion order or language specific sorting). The sorting is not defined by the data model, each codec should find the best sorting algorithm, but the sorting must be consitent between languages and is most often implemented as additional code during serialization since most formats do not already have deterministic maps.
+Codecs must be able to serialize Maps in a deterministic way (key sorting should be consistent regardless of insertion order or language specific sorting). The sorting is not defined by the data model, each codec should find the best sorting algorithm, but the sorting must be consistent between languages and is most often implemented as additional code during serialization since most formats do not already have deterministic maps.
 
 #### Link kind
 


### PR DESCRIPTION
In order to be “data model compliant” we should require deterministic maps.

This means that all the `dag-{format}` codecs must add deterministic key sorting during serialization. We should add the details for each codec in those codec specs, but there should be a general requirement that some form of determinism is defined.