### PR TITLE
hashmap: fix schema for current syntax & update links and descriptions of impls

### DIFF
--- a/data-structures/hashmap.md
+++ b/data-structures/hashmap.md
@@ -113,11 +113,11 @@ type Element union {
   | Bucket list
 } representation kinded
 
-type Bucket list [ BucketEntry ]
+type Bucket [ BucketEntry ]
 
 type BucketEntry struct {
   key Bytes
-  value Value (implicit "null")
+  value Value
 } representation tuple
 
 type Value union {

--- a/data-structures/hashmap.md
+++ b/data-structures/hashmap.md
@@ -42,8 +42,9 @@ The IPLD HashMap is constructed as a [hash array mapped trie (HAMT)](https://en.
 * [Java implementation](https://github.com/msteindorfer/oopsla15-artifact/) accompanying the original CHAMP paper (see https://github.com/msteindorfer/oopsla15-artifact/blob/master/pdb.values/src/org/eclipse/imp/pdb/facts/util/TrieMap_5Bits.java and other TrieMap files in the same directory).
 * [Optimizing Hash-Array Mapped Tries for Fast and Lean Immutable JVM Collections](https://blog.acolyer.org/2015/11/27/hamt/) a high-level description of HAMT data structures in general and the specifics of CHAMP.
 * Peergos [CHAMP](https://github.com/Peergos/Peergos/blob/master/src/peergos/shared/hamt/Champ.java) implementation
-* [IAMap](https://github.com/rvagg/iamap) JavaScript implementation
-* [go-hamt-ipld](https://github.com/ipfs/go-hamt-ipld) Go implementation
+* [IAMap](https://github.com/rvagg/iamap) JavaScript implementation of the algorithm
+* [ipld-hashmap](https://github.com/rvagg/js-ipld-hashmap) JavaScript IPLD frontend to IAMap with a mutable API
+* [go-hamt-ipld](https://github.com/ipfs/go-hamt-ipld) Go implementation, not strictly aligned to this spec
 
 ## Summary
 


### PR DESCRIPTION
Ref: #26 

1. `type Foo list [ Thing]` got shortened to `type Foo [ Thing ]` in schemas.
2. We removed the ability to do field modifiers on anything but map representation structs, so the tuple here with an implicit isn't allowed. This matches the current implementation I think https://github.com/rvagg/iamap/blob/fad95295b013c8b4f0faac6dd5d9be175f6e606c/iamap.js#L117-L119, but it would be nice to be able to say that the last field in a tuple representation struct can have an implicit, so that's a thing we could consider in a future iteration.

Mikeal also mentioned that the current JavaScript implementation via iamap doesn't match the schema, I'm not sure where exactly but I need to go through and figure that out. That's still a manual process while we lack solid tooling.

I've also updated the implementation links and descriptions. I didn't realise [ipld-hashmap](https://github.com/rvagg/js-ipld-hashmap) wasn't on the list. It's much more pleasant to use than IAMap directly.

Thanks @chafey for the heads-up.