### PR TITLE
Add request update, pause response code

### DIFF
--- a/block-layer/graphsync/graphsync.md
+++ b/block-layer/graphsync/graphsync.md
@@ -69,6 +69,7 @@ message GraphsyncMessage {
     map<string, bytes> extensions = 4; // side channel information
     int32 priority = 5;	// the priority (normalized). default to 1
     bool  cancel = 6;   // whether this cancels a request
+    bool  update = 7;   // whether this is an update to an in progress request
   }
 
   message Response {
@@ -99,6 +100,14 @@ Extensions help make Graphsync operate more efficiently, or provide a mechanism 
 
 A list of well known extensions is found [here](./known_extensions.md)
 
+### Updating requests
+
+A client may send an updated version of a request. 
+
+An update contains ONLY extension data, which the responder can use to modify an in progress request. For example, if a responder supports the Do Not Send CIDs extension, it could choose to also accept an update to this list and ignore CIDs encountered later. It is not possible to modify the original root and selector of a request through this mechanism. If this is what is needed, you should cancel the request and send a new one. 
+
+The update mechanism in conjunction with the paused response code can also be used to support incremental payment protocols.
+
 ### Response Status Codes
 
 ```
@@ -108,6 +117,7 @@ A list of well known extensions is found [here](./known_extensions.md)
 12   Not enough vespene gas ($)
 13   Other Protocol - info in extra.
 14   Partial Response w/ metadata, may include blocks
+15   Request Paused, pending update, see extensions for info
 
 # success - terminal
 20   Request Completed, full content.


### PR DESCRIPTION
# Goals

The update to GraphSync is intended to support future mechanisms for modifying an in progress request. Rather than define a complex update protocol, we simply add an update boolean to the request, indicating a request is an update to an already in progress request, and delegate what the update actually is to whatever extensions are shared between requestor and responder. We can promote actual types of updates to the core request structure as we determine them to be so useful they need to be standard across all GraphSync clients. However, at the moment, I do not any such update mechanisms are defined well enough to merit that. There will probably be a period of experimentation as we determine how to best spread out graphsync requests among multiple responders to quickly replicate IPLD graphs, and I think it's best to delegate to extensions until we determine effective ways to do this, so as not to break the core protocol. (thing we may want to add: way to query for supported extensions)

In addition, we define a paused response code -- your request is in progress, it hasn't error-ed, but it's halted pending additional information from you that you can send in an update request. This is useful for layering any kind of system for metering requests based on payment on top of graphsync.

# For discussion

- It is possible we could get away with not adding this boolean? if a request ID is received from a given peer by a responder, that already has a request with that ID in progress for that peer, arguably that implies an update? Seems like hiding that information as an implied result of the request already existing is not helpful

- Alternatively, rather than adding another boolean, we could add a request code, similar to an HTTP request code, and remove the cancel boolean and for now define request codes like:
10 - New request
20 - Update Request
30 - Cancel Request
(I'm just spitballing numbers here -- we could use other ones) 