### PR TITLE
DagJSON: Be more specific about Multibase Base64 encoding

### DIFF
--- a/block-layer/codecs/DAG-JSON.md
+++ b/block-layer/codecs/DAG-JSON.md
@@ -42,8 +42,8 @@ The Bytes kind is represented as an object with `"bytes"` as key and a [Multibas
 A link is represented as a base encoded CID. CIDv0 and CIDv1 are encoded differently.
 
  - CIDv1 is represented as a Multibase Base32 encoded string. The Base32 encoding is the one described in [RFC 4648, section 6](https://tools.ietf.org/html/rfc4648#section-6) without padding, hence the Multibase prefix is `b`.
- - CIDv0 is represented in its only possible Base58 encoding. The Base58 encoding is the one described in [Base58 draft](https://tools.ietf.org/html/draft-msporny-base58), hence the Multibase prefix is `Q`.
+ - CIDv0 is represented in its only possible Base58 encoding. The Base58 encoding is the one described in [Base58 draft](https://tools.ietf.org/html/draft-msporny-base58).
 
 ```javascript
-{"/": String /* Multibase Base58 encoded CIDv0 or Multibase Base32 encoded CIDv1 */}
+{"/": String /* Base58 encoded CIDv0 or Multibase Base32 encoded CIDv1 */}
 ```

--- a/block-layer/codecs/DAG-JSON.md
+++ b/block-layer/codecs/DAG-JSON.md
@@ -16,22 +16,34 @@ Codec implementors **MUST** do the following in order to ensure hashes consisten
 This produces the most compact and consistent representation which will ensure that two codecs
 producing the same data end up with matching block hashes.
 
-### Simple Types
+### Natively supported kinds
 
-All simple types except binary are supported natively by JSON.
+All kinds of the IPLD Data Model except Bytes and Link are supported natively by JSON.
 
 Contrary to popular belief, JSON as a format supports Big Integers. It's only
 JavaScript itself that has trouble with them. This means JS implementations
 of `dag-json` can't use the native JSON parser and serializer.
 
-#### Binary Type
+### Other kinds
+
+The non-natively supported kinds are wrapped in an object, where the key is a slash (`"/"`) and the value is the actual kind.
+
+#### Bytes kind
+
+The Bytes kind is represented as an object with `"bytes"` as key and a [Multibase](https://github.com/multiformats/multibase) Base64 encoded string as value. The Base64 encoding is the one described in [RFC 4648, section 4](https://tools.ietf.org/html/rfc4648#section-4) without padding, hence the Multibase prefix is `m`.
+
 
 ```javascript
-{"/": { "base64": String }}
+{"/": { "bytes": String /* Multibase Base64 encoded binary */ }}
 ```
 
-#### Link Type
+#### Link kind
+
+A link is represented as a base encoded CID. CIDv0 and CIDv1 are encoded differently.
+
+ - CIDv1 is represented as a Multibase Base32 encoded string. The Base32 encoding is the one described in [RFC 4648, section 6](https://tools.ietf.org/html/rfc4648#section-6) without padding, hence the Multibase prefix is `b`.
+ - CIDv0 is represented in its only possible Base58 encoding. The Base58 encoding is the one described in [Base58 draft](https://tools.ietf.org/html/draft-msporny-base58), hence the Multibase prefix is `Q`.
 
 ```javascript
-{"/": String /* base encoded CID */}
+{"/": String /* Multibase Base58 encoded CIDv0 or Multibase Base32 encoded CIDv1 */}
 ```


### PR DESCRIPTION
How CIDs are encoded was underspecified. The binary type is now also using
multibase instead of plain Base64.

Reasons for using Multibase instead of raw Base64:

 - It is clear which variant of Base64 is used
 - CID libraries support it natively
 - Having symmetry between different Base64 encded items makes it easier
   to remember and probably also the implementation easier to follow