### PR TITLE
fix: capitalize DAG correctly

### DIFF
--- a/FOUNDATIONS.md
+++ b/FOUNDATIONS.md
@@ -213,7 +213,7 @@ inline data into large objects (lots of duplication and copying).
 
 ## Primitives
 
-The "recommended" IPLD format (currently DagCBOR) needs to support *at a minimum*:
+The "recommended" IPLD format (currently DAG-CBOR) needs to support *at a minimum*:
 
 * 32/64 bit integers without losing information.
 * 32/64 bit floats without losing information.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This layer model is a simplified hierarchy of IPLD concepts and requirements.
 
 The block layer encompasses all content addressed block formats and specifies how blocks are addressed, how they self-describe their codec for encoding/decoding, and how blocks link between each other.
 
-This layer alone is enough to accomplish basic graph replication across a variety of formats (eth, bitcoin, git, dag-pb, dag-cbor, etc).
+This layer alone is enough to accomplish basic graph replication across a variety of formats (Ethereum, Bitcoin, Git, DAG-PB, DAG-CBOR, etc).
 
 This layer does not define data structures or types, although many codecs may convert these formats into native types, there are no type requirements or assurances about types at the block layer.
 
@@ -54,8 +54,8 @@ This layer does not define data structures or types, although many codecs may co
 | [Concept: Multihash](block-layer/multihash.md) | [block-layer/multihash.md](block-layer/multihash.md) |
 | [Concept: Serialization and Formats](block-layer/serialization-and-formats.md) | [block-layer/serialization-and-formats.md](block-layer/serialization-and-formats.md) |
 | [Specification: CIDs](block-layer/CID.md) | [block-layer/CID.md](block-layer/CID.md) |
-| [Specification: DagCBOR](block-layer/codecs/dag-cbor.md) | [block-layer/codecs/dag-cbor.md](block-layer/codecs/dag-cbor.md) |
-| [Specification: DagJSON](block-layer/codecs/dag-json.md) | [block-layer/codecs/dag-json.md](block-layer/codecs/dag-json.md) |
+| [Specification: DAG-CBOR](block-layer/codecs/dag-cbor.md) | [block-layer/codecs/dag-cbor.md](block-layer/codecs/dag-cbor.md) |
+| [Specification: DAG-JSON](block-layer/codecs/dag-json.md) | [block-layer/codecs/dag-json.md](block-layer/codecs/dag-json.md) |
 | [Specification: IPLD Selectors](selectors/selectors.md) | [selectors/selectors.md](selectors/selectors.md) |
 | [Specification: Graphsync](block-layer/graphsync/graphsync.md) | [block-layer/graphsync/graphsync.md](block-layer/graphsync/graphsync.md) |
 | [Specification: Content Addressable aRchives (CAR / .car)](block-layer/content-addressable-archives.md) | [block-layer/content-addressable-archives.md](block-layer/content-addressable-archives.md) |

--- a/block-layer/codecs/dag-cbor.md
+++ b/block-layer/codecs/dag-cbor.md
@@ -1,4 +1,4 @@
-# Specification: DagCBOR
+# Specification: DAG-CBOR
 
 **Status: Descriptive - Draft**
 
@@ -11,35 +11,35 @@
   * [JavaScript](#javascript)
   * [Go](#go)
 
-DagCBOR supports the full [IPLD Data Model].
+DAG-CBOR supports the full [IPLD Data Model].
 
-DagCBOR uses the [Concise Binary Object Representation (CBOR)] data format, which natively supports all [IPLD Data Model Kinds].
+DAG-CBOR uses the [Concise Binary Object Representation (CBOR)] data format, which natively supports all [IPLD Data Model Kinds].
 
 ## Format
 
-The CBOR IPLD format is called DagCBOR to disambiguate it from regular CBOR. Most CBOR objects are valid DagCBOR. The primary differences are:
+The CBOR IPLD format is called DAG-CBOR to disambiguate it from regular CBOR. Most CBOR objects are valid DAG-CBOR. The primary differences are:
   * tag `42` interpreted as CIDs
   * maps may only be keyed by strings
   * additional strictness requirements about valid data encoding forms
 
 ## Links
 
-As with all IPLD formats, DagCBOR must be able to encode [Links]. In DagCBOR, links are the binary form of a [CID] encoded using the raw-binary identity [Multibase]. That is, the Multibase identity prefix (`0x00`) is prepended to the binary form of a CID and this new byte array is encoded into CBOR as a byte-string (major type 2), with the tag `42`.
+As with all IPLD formats, DAG-CBOR must be able to encode [Links]. In DAG-CBOR, links are the binary form of a [CID] encoded using the raw-binary identity [Multibase]. That is, the Multibase identity prefix (`0x00`) is prepended to the binary form of a CID and this new byte array is encoded into CBOR as a byte-string (major type 2), with the tag `42`.
 
 The inclusion of the Multibase prefix exists for historical reasons and the identity prefix *must not* be omitted.
 
 ## Map Keys
 
-In DagCBOR, map keys must be strings, as defined by the [IPLD Data Model].
+In DAG-CBOR, map keys must be strings, as defined by the [IPLD Data Model].
 
 ## Strictness
 
-DagCBOR requires that there exist a single way of encoding any given object, and that encoded forms contain no superfluous data that may be ignored or lost in a round-trip decode/encode.
+DAG-CBOR requires that there exist a single way of encoding any given object, and that encoded forms contain no superfluous data that may be ignored or lost in a round-trip decode/encode.
 
-Therefore the DagCBOR codec must:
+Therefore the DAG-CBOR codec must:
 
-1. Use no tags other than the CID tag (`42`). A valid DagCBOR encoder must not encode using any additional tags and a valid DagCBOR decoder must reject objects containing additional tags as invalid.
-2. Use the canonical CBOR encoding defined by the the suggestions in [section 3.9 of the CBOR specification]. A valid DagCBOR decoder should reject objects not following these restrictions as invalid. Specifically:
+1. Use no tags other than the CID tag (`42`). A valid DAG-CBOR encoder must not encode using any additional tags and a valid DAG-CBOR decoder must reject objects containing additional tags as invalid.
+2. Use the canonical CBOR encoding defined by the the suggestions in [section 3.9 of the CBOR specification]. A valid DAG-CBOR decoder should reject objects not following these restrictions as invalid. Specifically:
    * Integer encoding must be as short as possible.
    * The expression of lengths in major types 2 through 5 must be as short as possible.
    * The keys in every map must be sorted lowest value to highest. Sorting is performed on the bytes of the representation of the keys.

--- a/block-layer/codecs/dag-json.md
+++ b/block-layer/codecs/dag-json.md
@@ -22,7 +22,7 @@ All kinds of the IPLD Data Model except Bytes and Link are supported natively by
 
 Contrary to popular belief, JSON as a format supports Big Integers. It's only
 JavaScript itself that has trouble with them. This means JS implementations
-of `dag-json` can't use the native JSON parser and serializer.
+of DAG-JSON can't use the native JSON parser and serializer.
 
 ### Other kinds
 

--- a/block-layer/codecs/dag-pb.md
+++ b/block-layer/codecs/dag-pb.md
@@ -1,12 +1,12 @@
-# DagPB Spec
+# DAG-PB Spec
 
 **Status: Descriptive - Draft**
 
-DagPB does not support the full ["IPLD Data Model."](../../data-model-layer/data-model.md)
+DAG-PB does not support the full ["IPLD Data Model."](../../data-model-layer/data-model.md)
 
 ## Format
 
-The DagPB IPLD format is a format implemented with a single protobuf.
+The DAG-PB IPLD format is a format implemented with a single protobuf.
 
 ```protobuf
 // An IPFS MerkleDAG Link
@@ -49,9 +49,9 @@ In the JavaScript implementation, there is an additional way to path through the
 These two ways of pathing can be combined, so you can access e.g. the `Data` field of a named link via `/<name/Data`. You can also use both approaches within a single path, e.g. `/<name1>/Links/0/Hash/Data` or `/Links/<index>/Hash/<name>/Data`. When using the DAG API in js-ipfs, then the pathing over the structure has precedence, so you won't be able to use named pathing on a named link called `Links`, you would need to use the index of the link instead.
 
 
-## Canonical DagPB
+## Canonical DAG-PB
 
-Canonical DagPB must:
+Canonical DAG-PB must:
 
 1. Contain only the specified protobuf fields.
 2. Use standard protobuf encoding, with the following field orders:

--- a/block-layer/content-addressable-archives.md
+++ b/block-layer/content-addressable-archives.md
@@ -51,7 +51,7 @@ The CAR format comprises a sequence of length-prefixed IPLD block data, where th
 ```
 |--------- Header --------| |---------------------------------- Data -----------------------------------|
 
-[ varint | dag-cbor block ] [ varint | CID | block ] [ varint | CID | block ] [ varint | CID | block ] …
+[ varint | DAG-CBOR block ] [ varint | CID | block ] [ varint | CID | block ] [ varint | CID | block ] …
 ```
 
 ### Header

--- a/schemas/authoring-guide.md
+++ b/schemas/authoring-guide.md
@@ -199,7 +199,7 @@ type Foo struct {
 }
 ```
 
-We could decode the following JSON (using the dag-json codec) into a `Foo` type:
+We could decode the following JSON (using the DAG-JSON codec) into a `Foo` type:
 
 ```json
 {


### PR DESCRIPTION
It's e.g. DAG-CBOR and not DagCBOR.

I only updated the specs and not the exploration reports as I would
just keep them as they are.