### PR TITLE
docs: cleanup for FlexibleByteLayout

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ The Schema Layer will also serve as an enabling layer for complex multi-block da
 | [Concept: IPLD Multi-block Collections](data-structures/multiblock-collections.md) | [data-structures/multiblock-collections.md](data-structures/multiblock-collections.md) |
 | [Specification: IPLD Schemas](schemas/README.md) | [schemas/README.md](schemas/README.md) |
 | [Specification: HashMap](data-structures/hashmap.md) | [data-structures/hashmap.md](data-structures/hashmap.md) |
+| [Specification: FlexibleByteLayout](data-structures/flexible-byte-layout.md) | [data-structures/flexible-byte-layout.md](data-structures/flexible-byte-layout.md) |
+
 
 ## Specification document status
 

--- a/data-structures/flexible-byte-layout.md
+++ b/data-structures/flexible-byte-layout.md
@@ -20,8 +20,9 @@ type NestedByte struct {
 } representation tuple
 ```
 
-`FlexibleByteLayout` uses a potentially recursive union type. This allows you to build very large nested
-dags via NestedByteList that can themselves contain additional NestedByteLists, links to BytesUnions.
+`FlexibleByteLayout` is the entrypoint/root of the data structure and uses a potentially recursive
+union type. This allows you to build very large nested dags via `NestedByteList` that can themselves
+contain additional `NestedByteList`s or actual `Bytes` (via Links to `FlexibleByteLayout` in `NestedByte`).  
 
 An implementation must define a custom function for reading ranges of binary
 data but once implemented, you can read data regardless of the layout algorithm used.
@@ -36,3 +37,4 @@ will not be able to read properly. However, the property is **not secure** and a
 could write it as whatever they please. As such, it should not be relied upon when calculating usage
 against a quota or any similar calculation where there may be an incentive for an encoder to alter the
 length.
+


### PR DESCRIPTION
renamed spec file from data.md to flexible-byte-layout.md
added link to flexible-byte-layout spec from top level readme
added prose about FlexibleByteLayout being the entrypoint/root of the data structure