### PR TITLE
proposal: specify hash algorithm by integer code in hashmap

### DIFF
--- a/data-structures/hashmap.md
+++ b/data-structures/hashmap.md
@@ -96,7 +96,7 @@ See [IPLD Schemas](../../schemas) for a definition of this format.
 ```ipldsch
 # Root node layout
 type HashMapRoot struct {
-  hashAlg String
+  hashAlg Int
   bucketSize Int
   map Bytes
   data [ Element ]


### PR DESCRIPTION
This might be worth doing since we’ve been trying to move away from string identifiers for multiformats. It’s also a little more compact when serialized.