### PR TITLE
feat: support inline bytes in a byte list

### DIFF
--- a/data-structures/flexible-byte-layout.md
+++ b/data-structures/flexible-byte-layout.md
@@ -10,13 +10,14 @@ It is flexible enough to support very small and very large (multi-block) binary 
 type FlexibleByteLayout union {
   | Bytes bytes
   | NestedByteList list
+  | &FlexibleByteLayout link
 } representation kinded
 
 type NestedByteList [ NestedByte ]
 
 type NestedByte struct {
   length Int
-  part &FlexibleByteLayout
+  part FlexibleByteLayout
 } representation tuple
 ```
 


### PR DESCRIPTION
This is a feature @ribasushi surfaced the need for recently. This comes up using smarter chunkers where you may have just a byte or two as separators and it’s smaller to inline them than to be forced to use a link.

@warpfork it seems a little weird to being using the `&` syntax in this union since it’s already kinded on the link, but I think it’s still correct right?