### PR TITLE
hashmap: document Filecoin HAMT variations

### DIFF
--- a/data-structures/hashmap.md
+++ b/data-structures/hashmap.md
@@ -28,6 +28,9 @@
   * [Hash algorithm](#Hash-algorithm)
   * [Buckets](#Buckets)
   * [Security](#Security)
+* [Appendix: Filecoin HAMT Variant](#Appendix-Filecoin-hamt-variant)
+  * [Implicit and fixed parameters](#Implicit-and-fixed-parameters)
+  * [Block layout](#Block-layout)
 
 ## Introduction
 
@@ -44,7 +47,7 @@ The IPLD HashMap is constructed as a [hash array mapped trie (HAMT)](https://en.
 * Peergos [CHAMP](https://github.com/Peergos/Peergos/blob/master/src/peergos/shared/hamt/Champ.java) implementation
 * [IAMap](https://github.com/rvagg/iamap) JavaScript implementation of the algorithm
 * [ipld-hashmap](https://github.com/rvagg/js-ipld-hashmap) JavaScript IPLD frontend to IAMap with a mutable API
-* [go-hamt-ipld](https://github.com/ipfs/go-hamt-ipld) Go implementation, not strictly aligned to this spec
+* [go-hamt-ipld](https://github.com/ipfs/go-hamt-ipld) Filecoin Go HAMT implementation used by the [Lotus](https://lotu.sh/) client. See the appendix for how this implementation differs from this specification.
 
 ## Summary
 
@@ -295,3 +298,55 @@ The impact on the data structure layout imposed by the use of buckets in the IPL
 ### Security
 
 As yet, there is no known hash collision attack vector against IPLD data structures. There may conceivably be use cases where user-input is able to impact `key`s and collisions against a chosen `hashAlg` are practical. In such cases, an IPLD HashMap could be built whereby it reaches its maximum depth of `(digestLength x 8) / bitWidth` quickly and further colliding additions cause errors and possible denial of service. The current use-cases of IPLD do not lend themselves to denial of service attacks of this kind. Further practical application and research may change this understanding and dictate the need for hash algorithms with large byte output and/or cryptographic hash algorithms without known collision flaws.
+
+## Appendix: Filecoin HAMT Variant
+
+The [Filecoin Project blockchain](https://filecoin-project.github.io/specs/) makes use of a HAMT that uses the same HAMT with buckets and CHAMP mutation semantics as outlined in this document. It encodes directly as [DAG-CBOR](../block-layer/codecs/dag-cbor.md) but uses a different block layout to the one specified here. This section documents the specific ways that the Filecoin HAMT variant differs from this specification. IPLD HashMap implementations may be able to implement a form that provides compatibility with Filecoin when requested by the user.
+
+The reference Go implementation for the Filecoin HAMT is used by the [Lotus](https://lotu.sh/) client and is available at <https://github.com/ipfs/go-hamt-ipld>.
+
+### Implicit and fixed parameters
+
+The Filecoin HAMT _does not_ use an explicit root block (`HashMapRoot`) to encode its parameters within the data. Instead it is expected that consumers of the data understand the parameters from a combination of the Filecoin specification and versioning of the blockchain over time. All HAMT nodes take the same form, there is no differentiation for a root node and an implementation must bring implicit parameters when decoding each node.
+
+* `hashAlg`: The hash algorithm used by the Filecoin HAMT is the x64 form of the 64-bit [MurmurHash3](https://github.com/aappleby/smhasher). _(TODO: this may be changed to SHA2-256 prior to Filecoin mainnet: https://github.com/filecoin-project/specs-actors/issues/517)_
+* `bitWidth`: The Filecoin HAMT fixes the bit width to `5`, meaning that each node of the HAMT can contain up to `2`<sup>`5`</sup> (`32`) elements containing either buckets or links to child nodes.
+* `bucketSize`: The Filecoin HAMT fixes the maximum length of its buckets to `3`, meaning a maximally full HAMT leaf node can contain `32 x 3` (`96`) key/value pairs.
+
+### Block layout
+
+An IPLD schema representing the Filecoin HAMT varies from the IPLD HashMap [schema](#Schema) so any implementation needing to read Filecoin HAMT blocks will need to handle its specific layout:
+
+```ipldsch
+type HashMapNode struct {
+  map Bytes
+  data [ Element ]
+} representation tuple
+
+type Element union {
+  | &HashMapNode "0"
+  | Bucket "1"
+} representation keyed
+
+type Bucket [ BucketEntry ]
+
+type BucketEntry struct {
+  key Bytes
+  value Value
+} representation tuple
+
+# There is currently no limitation on the types available for storage as long
+# as they can be decoded from the bytes. Currently the Filecoin HAMT is used
+# to store inline objects rather than links to objects.
+type Value union {
+  | Bool bool
+  | String string
+  | Bytes bytes
+  | Int int
+  | Float float
+  | Map map
+  | List list
+  | Link link
+} representation kinded
+```
+

--- a/data-structures/hashmap.md
+++ b/data-structures/hashmap.md
@@ -309,7 +309,7 @@ The reference Go implementation for the Filecoin HAMT is used by the [Lotus](htt
 
 The Filecoin HAMT _does not_ use an explicit root block (`HashMapRoot`) to encode its parameters within the data. Instead it is expected that consumers of the data understand the parameters from a combination of the Filecoin specification and versioning of the blockchain over time. All HAMT nodes take the same form, there is no differentiation for a root node and an implementation must bring implicit parameters when decoding each node.
 
-* `hashAlg`: The hash algorithm used by the Filecoin HAMT is the x64 form of the 64-bit [MurmurHash3](https://github.com/aappleby/smhasher). _(TODO: this may be changed to SHA2-256 prior to Filecoin mainnet: https://github.com/filecoin-project/specs-actors/issues/517)_
+* `hashAlg`: The hash algorithm used by the Filecoin HAMT is SHA2-256.
 * `bitWidth`: The Filecoin HAMT fixes the bit width to `5`, meaning that each node of the HAMT can contain up to `2`<sup>`5`</sup> (`32`) elements containing either buckets or links to child nodes.
 * `bucketSize`: The Filecoin HAMT fixes the maximum length of its buckets to `3`, meaning a maximally full HAMT leaf node can contain `32 x 3` (`96`) key/value pairs.
 


### PR DESCRIPTION
I believe this is correct as of now, but there's some potential modifications that may happen prior to mainnet.

This section will get linked from https://github.com/ipfs/go-hamt-ipld/pull/52 and the Filecoin specs which currently just point to the top of this doc.