### PR TITLE
dag-cbor: javascript number limitations

### DIFF
--- a/block-layer/codecs/dag-cbor.md
+++ b/block-layer/codecs/dag-cbor.md
@@ -84,23 +84,23 @@ One of these approaches will be chosen and the libraries for the other language 
 
 ### JavaScript
 
-Users of DAG-CBOR that expect that their data may be consumed or produced by JavaScript at some point should be aware of limitations that the language imposes on its use of DAG-CBOR, specifically concerning numbers.
+Users of DAG-CBOR that expect their data may be consumed or produced by JavaScript at some point should be aware of limitations that the language imposes on its use of DAG-CBOR, specifically concerning numbers.
 
 All JavaScript numbers, both floating point and integer, (using the [`Number`] primitive wrapper) are represented internally as 64-bit [IEEE 754] floating-point values (i.e. double-precision). Some implications within JavaScript of this design choice are:
 
- * By convention, JavaScript engines and developers usually omit the decimal point when representing whole numbers, simulating integers where the number is not actually stored as an integer.
  * There is no clear differentiation between a pure integer type and a floating-point number where a developer may wish to have such a differentiation.
- * There are limits on maximum and minimum safe integer sizes representable in JavaScript that are lower than those of languages where there are pure 64-bit integer types. Numbers outside of the range of `Number.MAX_SAFE_INTEGER` (`2`<sup>`53`</sup>` - 1`) and `Number.MIN_SAFE_INTEGER` (`-(2`<sup>`53`</sup>` - 1)`) cannot be safely manipulated of inspected as they incur rounding effects imposed by the IEEE 754 representation.
- * Bit-wise operations are not able to be performed outside of the 32-bit range.
+ * By convention, JavaScript engines and developers usually omit the decimal point when representing whole numbers, simulating integers where the number is not actually stored as an integer.
+ * There are limits on maximum and minimum safe integer sizes representable in JavaScript that are more constrained than those of languages where there are 64-bit integer types. Numbers outside of the range of `Number.MAX_SAFE_INTEGER` (`2`<sup>`53`</sup>` - 1`) and `Number.MIN_SAFE_INTEGER` (`-(2`<sup>`53`</sup>` - 1)`) cannot be safely manipulated or inspected as they incur rounding effects imposed by the IEEE 754 representation.
+ * Native bit-wise operations on "integers" are not able to be performed outside of the 32-bit range; larger numbers will be truncated.
 
-The current CBOR library used by the primary JavaScript DAG-CBOR implementation uses the [bignumber.js] library to handle large numbers, although reliance on its wrapper type is _not_ recommended by DAG-CBOR users.
+The current CBOR encoder/decoder used by the primary JavaScript DAG-CBOR implementation uses the [bignumber.js] library to handle large numbers in some cases, although reliance on its wrapper type is not recommended by DAG-CBOR users.
 
 The implications for DAG-CBOR of these limitaitons are:
 
- * Any `Number` serialized by the JavaScript CBOR encoder relies on a whole-number (`x % 1 === 0`) check to determine whether it should be encoded as an integer or a float.
+ * Any `Number` serialized by the JavaScript CBOR encoder relies on a whole-number check (e.g. `x % 1 === 0`) to determine whether it should be encoded as an integer or a float.
  * Any float deserialized by the JavaScript CBOR decoder that does not have a fractional component will be indistinguishable from an integer to a JavaScript program.
  * Any `Number` greater than `Number.MAX_SAFE_INTEGER` or less than `Number.MIN_SAFE_INTEGER` cannot be properly inspected for its whole-number status and is therefore encoded by the JavaScript CBOR encoder as float regardless of whether it is a whole-number or has a fractional component.
- * Any integer deserialized by the JavaScript CBOR decoder greater than `Number.MAX_SAFE_INTEGER` or less than `Number.MIN_SAFE_INTEGER` will be returned as a bignumber.js wrapper type, which may be unexpected to consumers.
+ * Any integer deserialized by the JavaScript CBOR decoder greater than `Number.MAX_SAFE_INTEGER` or less than `Number.MIN_SAFE_INTEGER` will be returned as a bignumber.js wrapper type, which may be unexpected to users and have unexpected effects on downstream code.
 
 A new [BigInt] built-in type is currently being adopted across JavaScript engines. Once support is widely available, it is expected that this type will assist with some of these challenges.
 


### PR DESCRIPTION
Exposing the nakedness of JavaScript's `Number` type and its implications for cross-language data communication.

Is this too much information for an otherwise compact doc? It seems valuable information to know for anyone wanting to cross language boundaries, but maybe I'm overthinking it.