### PR TITLE
feat: more compact representation for nested bytes

### DIFF
--- a/data-structures/flexible-byte-layout.md
+++ b/data-structures/flexible-byte-layout.md
@@ -15,7 +15,12 @@ type FlexibleByteLayout union {
 
 type NestedByteList [ NestedByte ]
 
-type NestedByte struct {
+type NestedByte union {
+  | Bytes bytes
+  | NestedFBL list
+} representation kinded
+
+type NestedFBL struct {
   length Int
   part FlexibleByteLayout
 } representation tuple


### PR DESCRIPTION
This allows for a more compact representation of nested inline bytes in a list. Since you don’t need the length of an inlined binary value this means we can drop the list and int encoding when we inline bytes.