### PR TITLE
Exploration Report on more ADL details.

### DIFF
--- a/design/history/exploration-reports/2019.12-manifesting-adls.md
+++ b/design/history/exploration-reports/2019.12-manifesting-adls.md
@@ -1,0 +1,199 @@
+Notes on Manifesting Advanced Data Layouts
+==========================================
+
+This document is to explore some questions about Advanced Data Layouts (ADLs)
+and how they're:
+
+- created,
+- documented,
+- shared,
+- and used.
+
+... and perhaps most importantly, what user stories touch each of those facets,
+how often we expect the same people to be carrying out more than one of those stories,
+and when not, what kind of coordination they would require between the parties;
+and finally, what all that implies for our library and API and spec designs.
+
+
+Recap of the story so far
+-------------------------
+
+- ADLs are a cutout in the IPLD ecosystem specs which describe some Strongly Recommended library features.
+- ADLs are a way to present information as matching the Data Model -- so that
+  it can be traversed and manipulated generically, like any other Data Model content --
+  while not making any specification about how the data is actually stored.
+	- Specifically, ADLs have the notable property of potentially using *multiple Blocks* in their content.
+- Examples of important ADLs we image:
+	- Presenting a Data Model `map`, while internally using multiple Blocks in a HAMT format.
+	- Presenting a Data Model `bytes`, while internally using some tree structure, and chunks defined by some rolling checksum.
+	- This is not an exclusive list: we expect to make it possible for users to make their own ADLs.
+- It is important to note that ADLs use some *code* in order to do their internal work.
+	- Often this code will be written the native language of whatever library ecosystem you're using;
+	  it may also be a interpreted code in some virtual machine; this is not a detail that's important here.
+	- ADLs should be *specification driven*, so that it's not an undue burden to implement one natively
+	  in a language that currently doesn't have such an implementation.
+	- Since ADLs use *code*, it follows that security conscious library users will want to whitelist ADLs
+	  which they'll allow the use of.  (This may be for resource accounting and DoS prevention, if nothing else.)
+
+ADLs are a tricky feature because they're intentionally somewhat open-ended
+(so that they're extensible and can be applied to use cases in the future we didn't expect in advance),
+yet still need to follow enough higher level rules that systems designed on IPLD remain understandable and reliable.
+
+So: what are some more higher level rules we can establish?
+
+
+Rules We're Fairly Sure We Want
+-------------------------------
+
+### consuming in the realm of IPLD Schema tooling
+
+- When I parse a schema, I want to validate that all types it references are defined at this time.
+  It is an error to not be able to tell, or to have dangling references.
+- When I parse a schema, I should be able to tell what _kind_ all types are at this time.
+  It is necessary to do this so we can perform additional sanity checks, such as that kinded unions are coherent.
+- When I parse a schema, I should be able to see if any advanced layouts will be required in order to fully understand this data.
+  (It is not necessary for the ADL implementations to be provided in order for me to parse this schema; I just need to see where they will slot in.)
+
+### consuming in the realm of coding against IPLD libraries
+
+- As a user writing code using an IPLD library, we should be able to use ADLs... with the Data Model interfaces.
+  No interfaces for IPLD Schema features should be necessary to reference to in order to activate an ADL.
+  This may be _verbose_, but it should be _possible_.
+- As a user who *does* use IPLD Schemas, I should be additionally empowered:
+  I should be able to take the Schema's hints about where ADLs will be required, and supply implementations up front.
+  (This can be expected to be less verbose than the above, because all schematicADLname->ADLimpl mappings can be declared once, _up front_,
+  rather than ADLimpl mappings being handled by programmatic logic that has to be applied mid-tree.)
+
+### consuming in the realm of generic behaviors
+
+(n.b. making up a word for this.
+Means: things like "take this data CID, this schema CID, and this selector CID, and evaluate it";
+this is something we expect tooling to be able to evaluate from those declarations -- _without writing code_,
+which makes it a very distinct story from what's covered in the previous heading.)
+
+- In the story "take this data CID, this schema CID, and this selector CID"...
+	- If **no** ADL is involved, we simply expect this to succeed.
+	- If an ADL **is** involved, it should either succeed, or fail *clearly* (and as soon as possible).
+	- If an ADL **is** involved, we should be able to provide an additional argument of "{schematicADLname}->{ADLimpl}" in order to succeed.
+
+### authoring
+
+(_We're much less sure about authoring.  This is the big exploration topic right now._)
+
+### local naming
+
+I've used the term "schematicADLname" to above refer to the _local_ name of an ADL in a schema _using_ it.
+
+E.g., "Fwee" and "Fwop" in the following schema are each an schematicADLname:
+
+```ipldsch
+advanced Fwee {
+	kind map
+}
+advanced Fwop {
+	kind bytes
+}
+
+type FancyBytes bytes
+  representation advanced Fwop
+
+type FancyMap {String:String}
+  representation advanced Fwee
+```
+
+It may be important to disambiguate schematicADLname from the name or reference handle
+used for the ADL in any other context.
+
+For example, note that the story for consuming ADLs as library user includes two paths:
+and one of them *does not allude to "schematicADLname"* whatsoever.
+
+It's also important to note that the name an author of an ADL uses versus
+the name used locally in a consuming schema are not assumed to be in lock-step.
+(If they were, it would raise all sorts of questions about coordination,
+updating, etc, to which we have not yet posed concrete answers.)
+
+In fact, it's unclear if an author of an ADL even needs to name it at all in order to use it.
+
+
+Current Discussion
+------------------
+
+### Do we need a syntax for stating an ADL is to be "exported"?
+
+(Whatever "exported" means -- this has itself not yet been fully described.)
+
+Unclear.
+
+We may certainly find it *nice*, for documentation purposes.
+
+### Is such a syntax part of the Schema DSL?
+
+If the answer to the above question is "yes":
+Should it be in a similar syntax and in the same files as schema DSL statements?
+
+Unclear.
+
+Further exploratory questions:
+
+- Does it make sense to be able to export more than one ADL from the same file?
+	- How often will two different ADLs share internal types?
+		- Does it matter?  Would "vendoring" the defn's twice hurt anyone or make anything impossible?
+
+### What information might be useful in an "export" declaration for an ADL?
+
+"RootType" specifically recurs often as an idea that seems potentially useful.
+
+Question: if the code for the ADL impl defacto needs to refer to this type,
+is it strictly necessary to state it (redundantly) in the export declaration?
+
+Do we expect consumers of ADLs to be able to inspect the ADL's Schema,
+even if they _do not_ evaluate its _code_?
+Does that unlock any interesting features?  (Maybe!)
+
+### Are ADLs required to have a schema describing their internal data?
+
+("required" as in RFC 6919 "MUST")
+
+_Probably not._
+At least, there's been no explicit choice -- so far -- to mandate it.
+
+We might expect most of them to, because it's just a high-leverage, useful choice.
+We imagine ourselves using schemas to develop the ADLs we're authoring!
+But "a good idea" and a "must" are different things.
+
+Sub-question: Do we expect ADLs to have _exactly one_ (not two or more) schema?
+
+_**Probably not**_ -- use of multiple schemas in a "try stack" might be a useful feature
+for the ADL code author to do version detection and graceful migrations... just like anywhere else.
+
+
+
+Resolutions and Bets
+--------------------
+
+### making library APIs for ADLs
+
+Yes.  Let's do it.  Purely a forward and learning experience,
+and we're almost certain to need it regardless.
+
+### proposing properties for declarative manifests required for exporting ADLs
+
+Maybe?
+
+We can make drafts and proposals around this that are free-standing,
+so it's probably very viable to experiment with this freely.
+
+### proposing IPLD Schema DSL syntax for ADL export manifests
+
+Maybe?
+
+This is relatively difficult to do as an experiment of limited scope.
+
+### review this again
+
+In a few months, after experimenting with library APIs, we'll probably have
+additional experiences which will be useful input for reviewing this design.
+
+Ideally, we'd like to gain those experiences in more than one library and language.
+
+Let's make a point to re-check these ideas as that info becomes available.


### PR DESCRIPTION
(This is a buffered document cache flushing.)

This is a document from back at the end of 2019 about ADLs.

Some of this might already be experiencing [zeerust](https://tvtropes.org/pmwiki/pmwiki.php/Main/Zeerust), but I'd like to track it in history as a snapshot of where our design and development conversation was at, at the time.  (It's probably going to be good fodder for future generations of docs writing.  And as far as I can tell, it might be the first time a couple of things were stated clearly -- like "are ADLs _required_ to have an internal schema"->"no" -- so it'd be nice to track those.)

@mikeal , @rvagg , we had a meeting over this one.  Monstrously, I've lost the notes.  Are we alright merging this anyway?  IIRC, the live notes were mostly about syntax and got pretty muddy, so we might be better off re-doing that part of conversation in the future anyway.