### PR TITLE
Potential schema-schema changes.

### DIFF
--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -1,41 +1,42 @@
 {
 	"types": {
 		"TypeName": {
-			"kind": "string"
+			"string": {}
 		},
 		"SchemaMap": {
-			"kind": "map",
-			"keyType": "TypeName",
-			"valueType": "Type"
-		},
-		"AdvancedDataLayoutName": {
-			"kind": "string"
-		},
-		"AdvancedDataLayoutMap": {
-			"kind": "map",
-			"keyType": "AdvancedDataLayoutName",
-			"valueType": "AdvancedDataLayout"
-		},
-		"Schema": {
-			"kind": "struct",
-			"fields": {
-				"types": {
-					"type": "SchemaMap"
-				},
-				"advanced": {
-					"type": "AdvancedDataLayoutMap"
-				}
-			},
-			"representation": {
-				"map": {}
+			"map": {
+				"keyType": "TypeName",
+				"valueType": "TypeDefn"
 			}
 		},
-		"Type": {
-			"kind": "union",
-			"representation": {
-				"inline": {
-					"discriminantKey": "kind",
-					"discriminantTable": {
+		"AdvancedDataLayoutName": {
+			"string": {}
+		},
+		"AdvancedDataLayoutMap": {
+			"map": {
+				"keyType": "AdvancedDataLayoutName",
+				"valueType": "AdvancedDataLayout"
+			}
+		},
+		"Schema": {
+			"struct": {
+				"fields": {
+					"types": {
+						"type": "SchemaMap"
+					},
+					"advanced": {
+						"type": "AdvancedDataLayoutMap"
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"TypeDefn": {
+			"union": {
+				"representation": {
+					"keyed": {
 						"bool": "TypeBool",
 						"string": "TypeString",
 						"bytes": "TypeBytes",
@@ -53,384 +54,416 @@
 			}
 		},
 		"TypeKind": {
-			"kind": "enum",
-			"members": {
-				"Bool": null,
-				"String": null,
-				"Bytes": null,
-				"Int": null,
-				"Float": null,
-				"Map": null,
-				"List": null,
-				"Link": null,
-				"Union": null,
-				"Struct": null,
-				"Enum": null
-			},
-			"representation": {
-				"string": {}
+			"enum": {
+				"members": {
+					"Bool": {},
+					"String": {},
+					"Bytes": {},
+					"Int": {},
+					"Float": {},
+					"Map": {},
+					"List": {},
+					"Link": {},
+					"Union": {},
+					"Struct": {},
+					"Enum": {}
+				},
+				"representation": {
+					"string": {}
+				}
 			}
 		},
 		"RepresentationKind": {
-			"kind": "enum",
-			"members": {
-				"Bool": null,
-				"String": null,
-				"Bytes": null,
-				"Int": null,
-				"Float": null,
-				"Map": null,
-				"List": null,
-				"Link": null
-			},
-			"representation": {
-				"string": {}
+			"enum": {
+				"members": {
+					"Bool": {},
+					"String": {},
+					"Bytes": {},
+					"Int": {},
+					"Float": {},
+					"Map": {},
+					"List": {},
+					"Link": {}
+				},
+				"representation": {
+					"string": {}
+				}
 			}
 		},
 		"AnyScalar": {
-			"kind": "union",
-			"representation": {
-				"kinded": {
-					"bool": "Bool",
-					"string": "String",
-					"bytes": "Bytes",
-					"int": "Int",
-					"float": "Float"
+			"union": {
+				"representation": {
+					"kinded": {
+						"bool": "Bool",
+						"string": "String",
+						"bytes": "Bytes",
+						"int": "Int",
+						"float": "Float"
+					}
 				}
 			}
 		},
 		"AdvancedDataLayout": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeBool": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeString": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeBytes": {
-			"kind": "struct",
-			"fields": {
+			"struct": {
+				"fields": {
+					"representation": {
+						"type": "BytesRepresentation"
+					}
+				},
 				"representation": {
-					"type": "BytesRepresentation"
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"BytesRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"bytes": "BytesRepresentation_Bytes",
-					"advanced": "AdvancedDataLayoutName"
+			"union": {
+				"representation": {
+					"keyed": {
+						"bytes": "BytesRepresentation_Bytes",
+						"advanced": "AdvancedDataLayoutName"
+					}
 				}
 			}
 		},
 		"BytesRepresentation_Bytes": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeInt": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeFloat": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeMap": {
-			"kind": "struct",
-			"fields": {
-				"keyType": {
-					"type": "TypeName"
-				},
-				"valueType": {
-					"type": "TypeTerm"
-				},
-				"valueNullable": {
-					"type": "Bool"
+			"struct": {
+				"fields": {
+					"keyType": {
+						"type": "TypeName"
+					},
+					"valueType": {
+						"type": "TypeNameOrInlineDefn"
+					},
+					"valueNullable": {
+						"type": "Bool"
+					},
+					"representation": {
+						"type": "MapRepresentation"
+					}
 				},
 				"representation": {
-					"type": "MapRepresentation"
-				}
-			},
-			"representation": {
-				"map": {
-					"fields": {
-						"valueNullable": {
-							"implicit": false
+					"map": {
+						"fields": {
+							"valueNullable": {
+								"implicit": false
+							}
 						}
 					}
 				}
 			}
 		},
 		"MapRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"map": "MapRepresentation_Map",
-					"stringpairs": "MapRepresentation_StringPairs",
-					"listpairs": "MapRepresentation_ListPairs",
-					"advanced": "AdvancedDataLayoutName"
+			"union": {
+				"representation": {
+					"keyed": {
+						"map": "MapRepresentation_Map",
+						"stringpairs": "MapRepresentation_StringPairs",
+						"listpairs": "MapRepresentation_ListPairs",
+						"advanced": "AdvancedDataLayoutName"
+					}
 				}
 			}
 		},
 		"MapRepresentation_Map": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"MapRepresentation_StringPairs": {
-			"kind": "struct",
-			"fields": {
-				"innerDelim": {
-					"type": "String"
+			"struct": {
+				"fields": {
+					"innerDelim": {
+						"type": "String"
+					},
+					"entryDelim": {
+						"type": "String"
+					}
 				},
-				"entryDelim": {
-					"type": "String"
+				"representation": {
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"MapRepresentation_ListPairs": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeList": {
-			"kind": "struct",
-			"fields": {
-				"valueType": {
-					"type": "TypeTerm"
-				},
-				"valueNullable": {
-					"type": "Bool"
+			"struct": {
+				"fields": {
+					"valueType": {
+						"type": "TypeNameOrInlineDefn"
+					},
+					"valueNullable": {
+						"type": "Bool"
+					},
+					"representation": {
+						"type": "ListRepresentation"
+					}
 				},
 				"representation": {
-					"type": "ListRepresentation"
-				}
-			},
-			"representation": {
-				"map": {
-					"fields": {
-						"valueNullable": {
-							"implicit": false
+					"map": {
+						"fields": {
+							"valueNullable": {
+								"implicit": false
+							}
 						}
 					}
 				}
 			}
 		},
 		"ListRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"list": "ListRepresentation_List",
-					"advanced": "AdvancedDataLayoutName"
+			"union": {
+				"representation": {
+					"keyed": {
+						"list": "ListRepresentation_List",
+						"advanced": "AdvancedDataLayoutName"
+					}
 				}
 			}
 		},
 		"ListRepresentation_List": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"TypeLink": {
-			"kind": "struct",
-			"fields": {
-				"expectedType": {
-					"type": "String"
-				}
-			},
-			"representation": {
-				"map": {
-					"fields": {
-						"expectedType": {
-							"implicit": "Any"
+			"struct": {
+				"fields": {
+					"expectedType": {
+						"type": "String"
+					}
+				},
+				"representation": {
+					"map": {
+						"fields": {
+							"expectedType": {
+								"implicit": "Any"
+							}
 						}
 					}
 				}
 			}
 		},
 		"TypeUnion": {
-			"kind": "struct",
-			"fields": {
+			"struct": {
+				"fields": {
+					"representation": {
+						"type": "UnionRepresentation"
+					}
+				},
 				"representation": {
-					"type": "UnionRepresentation"
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		},
 		"UnionRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"kinded": "UnionRepresentation_Kinded",
-					"keyed": "UnionRepresentation_Keyed",
-					"envelope": "UnionRepresentation_Envelope",
-					"inline": "UnionRepresentation_Inline",
-					"byteprefix": "UnionRepresentation_BytePrefix"
+			"union": {
+				"representation": {
+					"keyed": {
+						"kinded": "UnionRepresentation_Kinded",
+						"keyed": "UnionRepresentation_Keyed",
+						"envelope": "UnionRepresentation_Envelope",
+						"inline": "UnionRepresentation_Inline",
+						"byteprefix": "UnionRepresentation_BytePrefix"
+					}
 				}
 			}
 		},
 		"UnionRepresentation_Kinded": {
-			"kind": "map",
-			"keyType": "RepresentationKind",
-			"valueType": "TypeName"
+			"map": {
+				"keyType": "RepresentationKind",
+				"valueType": "TypeName"
+			}
 		},
 		"UnionRepresentation_Keyed": {
-			"kind": "map",
-			"keyType": "String",
-			"valueType": "TypeName"
+			"map": {
+				"keyType": "String",
+				"valueType": "TypeName"
+			}
 		},
 		"UnionRepresentation_Envelope": {
-			"kind": "struct",
-			"fields": {
-				"discriminantKey": {
-					"type": "String"
-				},
-				"contentKey": {
-					"type": "String"
-				},
-				"discriminantTable": {
-					"type": {
-						"kind": "map",
-						"keyType": "String",
-						"valueType": "TypeName"
-					}
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"UnionRepresentation_Inline": {
-			"kind": "struct",
-			"fields": {
-				"discriminantKey": {
-					"type": "String"
-				},
-				"discriminantTable": {
-					"type": {
-						"kind": "map",
-						"keyType": "String",
-						"valueType": "TypeName"
-					}
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"UnionRepresentation_BytePrefix": {
-			"kind": "struct",
-			"fields": {
-				"discriminantTable": {
-					"type": {
-						"kind": "map",
-						"keyType": "TypeName",
-						"valueType": "Int"
-					}
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"TypeStruct": {
-			"kind": "struct",
-			"fields": {
+			"struct": {
 				"fields": {
-					"type": {
-						"kind": "map",
-						"keyType": "FieldName",
-						"valueType": "StructField"
+					"discriminantKey": {
+						"type": "String"
+					},
+					"contentKey": {
+						"type": "String"
+					},
+					"discriminantTable": {
+						"type": {
+							"map": {
+								"keyType": "String",
+								"valueType": "TypeName"
+							}
+						}
 					}
 				},
 				"representation": {
-					"type": "StructRepresentation"
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
+			}
+		},
+		"UnionRepresentation_Inline": {
+			"struct": {
+				"fields": {
+					"discriminantKey": {
+						"type": "String"
+					},
+					"discriminantTable": {
+						"type": {
+							"map": {
+								"keyType": "String",
+								"valueType": "TypeName"
+							}
+						}
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"UnionRepresentation_BytePrefix": {
+			"struct": {
+				"fields": {
+					"discriminantTable": {
+						"type": {
+							"map": {
+								"keyType": "TypeName",
+								"valueType": "Int"
+							}
+						}
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"TypeStruct": {
+			"struct": {
+				"fields": {
+					"fields": {
+						"type": {
+							"map": {
+								"keyType": "FieldName",
+								"valueType": "StructField"
+							}
+						}
+					},
+					"representation": {
+						"type": "StructRepresentation"
+					}
+				},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"FieldName": {
-			"kind": "string"
+			"string": {}
 		},
 		"StructField": {
-			"kind": "struct",
-			"fields": {
-				"type": {
-					"type": "TypeTerm"
+			"struct": {
+				"fields": {
+					"type": {
+						"type": "TypeNameOrInlineDefn"
+					},
+					"optional": {
+						"type": "Bool"
+					},
+					"nullable": {
+						"type": "Bool"
+					}
 				},
-				"optional": {
-					"type": "Bool"
-				},
-				"nullable": {
-					"type": "Bool"
-				}
-			},
-			"representation": {
-				"map": {
-					"fields": {
-						"optional": {
-							"implicit": false
-						},
-						"nullable": {
-							"implicit": false
+				"representation": {
+					"map": {
+						"fields": {
+							"optional": {
+								"implicit": false
+							},
+							"nullable": {
+								"implicit": false
+							}
 						}
 					}
 				}
 			}
 		},
-		"TypeTerm": {
-			"kind": "union",
-			"representation": {
-				"kinded": {
-					"string": "TypeName",
-					"map": "InlineDefn"
+		"TypeNameOrInlineDefn": {
+			"union": {
+				"representation": {
+					"kinded": {
+						"string": "TypeName",
+						"map": "TypeDefnInline"
+					}
 				}
 			}
 		},
-		"InlineDefn": {
-			"kind": "union",
-			"representation": {
-				"inline": {
-					"discriminantKey": "kind",
-					"discriminantTable": {
+		"TypeDefnInline": {
+			"union": {
+				"representation": {
+					"keyed": {
 						"map": "TypeMap",
 						"list": "TypeList"
 					}
@@ -438,152 +471,168 @@
 			}
 		},
 		"StructRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"map": "StructRepresentation_Map",
-					"tuple": "StructRepresentation_Tuple",
-					"stringpairs": "StructRepresentation_StringPairs",
-					"stringjoin": "StructRepresentation_StringJoin",
-					"listpairs": "StructRepresentation_ListPairs"
+			"union": {
+				"representation": {
+					"keyed": {
+						"map": "StructRepresentation_Map",
+						"tuple": "StructRepresentation_Tuple",
+						"stringpairs": "StructRepresentation_StringPairs",
+						"stringjoin": "StructRepresentation_StringJoin",
+						"listpairs": "StructRepresentation_ListPairs"
+					}
 				}
 			}
 		},
 		"StructRepresentation_Map": {
-			"kind": "struct",
-			"fields": {
+			"struct": {
 				"fields": {
-					"type": {
-						"kind": "map",
-						"keyType": "FieldName",
-						"valueType": "StructRepresentation_Map_FieldDetails"
-					},
-					"optional": true
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StructRepresentation_Map_FieldDetails": {
-			"kind": "struct",
-			"fields": {
-				"rename": {
-					"type": "String",
-					"optional": true
-				},
-				"implicit": {
-					"type": "AnyScalar",
-					"optional": true
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StructRepresentation_Tuple": {
-			"kind": "struct",
-			"fields": {
-				"fieldOrder": {
-					"type": {
-						"kind": "list",
-						"valueType": "FieldName"
-					},
-					"optional": true
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StructRepresentation_StringPairs": {
-			"kind": "struct",
-			"fields": {
-				"innerDelim": {
-					"type": "String"
-				},
-				"entryDelim": {
-					"type": "String"
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StructRepresentation_StringJoin": {
-			"kind": "struct",
-			"fields": {
-				"join": {
-					"type": "String"
-				},
-				"fieldOrder": {
-					"type": {
-						"kind": "list",
-						"valueType": "FieldName"
-					},
-					"optional": true
-				}
-			},
-			"representation": {
-				"map": {}
-			}
-		},
-		"StructRepresentation_ListPairs": {
-			"kind": "struct",
-			"fields": {},
-			"representation": {
-				"map": {}
-			}
-		},
-		"TypeEnum": {
-			"kind": "struct",
-			"fields": {
-				"members": {
-					"type": {
-						"kind": "map",
-						"keyType": "EnumValue",
-						"valueType": "Null"
+					"fields": {
+						"type": {
+							"map": {
+								"keyType": "FieldName",
+								"valueType": "StructRepresentation_Map_FieldDetails"
+							}
+						},
+						"optional": true
 					}
 				},
 				"representation": {
-					"type": "EnumRepresentation"
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
+			}
+		},
+		"StructRepresentation_Map_FieldDetails": {
+			"struct": {
+				"fields": {
+					"rename": {
+						"type": "String",
+						"optional": true
+					},
+					"implicit": {
+						"type": "AnyScalar",
+						"optional": true
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"StructRepresentation_Tuple": {
+			"struct": {
+				"fields": {
+					"fieldOrder": {
+						"type": {
+							"list": {
+								"valueType": "FieldName"
+							}
+						},
+						"optional": true
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"StructRepresentation_StringPairs": {
+			"struct": {
+				"fields": {
+					"innerDelim": {
+						"type": "String"
+					},
+					"entryDelim": {
+						"type": "String"
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"StructRepresentation_StringJoin": {
+			"struct": {
+				"fields": {
+					"join": {
+						"type": "String"
+					},
+					"fieldOrder": {
+						"type": {
+							"list": {
+								"valueType": "FieldName"
+							}
+						},
+						"optional": true
+					}
+				},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"StructRepresentation_ListPairs": {
+			"struct": {
+				"fields": {},
+				"representation": {
+					"map": {}
+				}
+			}
+		},
+		"TypeEnum": {
+			"struct": {
+				"fields": {
+					"members": {
+						"type": {
+							"map": {
+								"keyType": "EnumValue",
+								"valueType": "Unit"
+							}
+						}
+					},
+					"representation": {
+						"type": "EnumRepresentation"
+					}
+				},
+				"representation": {
+					"map": {}
+				}
 			}
 		},
 		"EnumValue": {
-			"kind": "string"
+			"string": {}
 		},
 		"EnumRepresentation": {
-			"kind": "union",
-			"representation": {
-				"keyed": {
-					"string": "EnumRepresentation_String",
-					"int": "EnumRepresentation_Int"
+			"union": {
+				"representation": {
+					"keyed": {
+						"string": "EnumRepresentation_String",
+						"int": "EnumRepresentation_Int"
+					}
 				}
 			}
 		},
 		"EnumRepresentation_String": {
-			"kind": "map",
-			"keyType": "EnumValue",
-			"valueType": "String"
+			"map": {
+				"keyType": "EnumValue",
+				"valueType": "String"
+			}
 		},
 		"EnumRepresentation_Int": {
-			"kind": "map",
-			"keyType": "EnumValue",
-			"valueType": "Int"
+			"map": {
+				"keyType": "EnumValue",
+				"valueType": "Int"
+			}
 		},
 		"TypeCopy": {
-			"kind": "struct",
-			"fields": {
-				"fromType": {
-					"type": "TypeName"
+			"struct": {
+				"fields": {
+					"fromType": {
+						"type": "TypeName"
+					}
+				},
+				"representation": {
+					"map": {}
 				}
-			},
-			"representation": {
-				"map": {}
 			}
 		}
 	}


### PR DESCRIPTION
This is going to be a "draft" PR for discussion -- if anything comes of it, it'll probably be done by breaking out smaller diffs after discussion.

These are some potential changes to the schema-schema that I've developed while exercising things over in https://github.com/ipld/go-ipld-prime/pull/76 .

- All the unions are now keyed.  Previously TypeDefn and TypeDefnInline   were using "inline" representation.  This results in most of the diff (it changes the indentation of quite a few things).
  - This seems desirable because keyed unions are the thing that we generally recommend the most highly be default (because in turn they're the most parser-friendly).
  - It was also awfully convenient for the sake of development over in the aforementioned PR, because we have codegen implemented for keyed union representations, but not for inline representations.  (Not a reason that'll endure, but kind of interesting to note, because this also has a reason in turn: the support for keyed unions is much, much easier to write than that for inline representations (and we might expect this to be noticed by other implementers of these systems in new languages in the future).)

- There's now a "Unit" type in play.  The definition of this can be approximated by an empty struct -- the semantic is that it must have a cardinality of one.  We need to add this concept to the schema system.  (I think I've mentioned this elsewhere, but if not, now it's mentioned!)
  - I've referred to it, but haven't actually added this type to the diff, because I think we may want to add a "unit" kind and also a "Unit" _type_ to the "prelude" (i.e. just like "String" is in the "prelude" and always means `type String string`).

- Enums are specified using the 'Unit' type.  Which means serially, they now have `{}` inside them instead of `null`.  This might be a temporary change: it's a consequence of the idea to emulate Unit by use of an empty struct, and if we give "unit" its own kind, we could give it its own selection of representation strategies (which could then include a choice of a representation like "null").
  - Previously, enums internally had an allusion to a "Null" type, which was *also* not defined in the schema-schema, so clarifying this to into Unit is the same or better as before, and addressing the Unit-related todos will make it entirely proper.
  - This also means I was able to actually parse the dang thing, over in my implementation PR, by indeed using a dummy declaration of Unit to be an empty struct.

There are also some renames which I felt improved clarity:

- Type -> TypeDefn
- InlineDefn -> TypeDefnInline
- TypeTerm -> TypeNameOrInlineDefn

I haven't altered the schema-schema DSL file to match yet.  That diff would be quite a bit smaller (since it wouldn't have the indent change effect from the switch of union representation).