### PR TITLE
Add exploration report about Numbers and IPLD Codecs

### DIFF
--- a/design/history/exploration-reports/2020.10-data-model-numbers-and-codecs.md
+++ b/design/history/exploration-reports/2020.10-data-model-numbers-and-codecs.md
@@ -1,0 +1,77 @@
+IPLD Data Model numbers and Ipld Codecs
+=======================================
+
+**Author**: Volker Mische ([@vmx])
+
+This is an exploration report about how to serialize [IPLD Data Model] numbers into bytes and back.
+
+
+Canonical representations
+-------------------------
+
+In IPLD it's desirable to have one single representation for every instance of the Data Model. This would lead to a bijective mapping between the Data Model and the encoded bytes. If you have a Data Model instance and you use a specific codec, it should always result in the same bytes, independent of the programming language used. That's important for content-addressing.
+
+
+### Conversion into the Data Model
+
+This looks like a hard problem, e.g. if you look at this IPFS issue with [DAG-CBOR] where there is a [different encoding between JavaScript and Go when numbers are integers]. Though in this issue, the problem is **not** the Data Model to Codec conversion. The problem is the **input data to Data Model conversion**. It took me a long time to figure that out.
+
+When I think of the IPLD Data Model I often think in terms of JSON and having numbers represented as text. I then think about how to represent those things as bytes. If you think about it that way, you have problems like: is `4251.00` and `4251` the same number? If yes, then it should be encoded the same way?
+
+From a Data Model perspective that's a non-issue. You have two kinds of numbers: [Integer] and [Float]. You can clearly distinguish between `Integer(4251)` and `Float(4251)`.
+
+
+### Serializing the Data Model
+
+
+#### Codec with multiple integer/float sizes
+
+Even within the Data Model there might be ambiguities, depending on Codec you use. If your Codec supports more than one integer type (which is often the case), you need to decide which one to choose. The obvious way is what CBOR in its [canonical representation] is doing:
+
+> Integers must be as small as possible.
+
+This means that a codec that supports 8-bit to 64-bit integers will encode `8472` always as `0x2118` and never as `0x00002118`.
+
+For floating point numbers (I always mean [binary IEEE-754 floating point numbers], others don't matter in modern day computing) the same issue arises. If your codec supports more than one floating point number type, e.g. 32-bit single precision and 64-bit double precision, a number like [`0.199951171875`] could be represented as `0x3e4cc000` (32-bit) or `0x3fc9980000000000` (64-bit). You can, just as with integers, require the smallest lossless representation of a float.
+
+Such a conversion to the smallest possible float makes sense for the sake of having a canonical representation, it doesn't make sense for space savings. Only about 0.00000002% of all the 64-bit floats can be represented as 32-bit floats. So it's not that likely that your data contains exactly those floats.
+
+
+#### Codecs with one type for integers and one for floats
+
+If you restrict your Codec to a single integer and a single float type, the conversion from the Codec into the IPLD Data Model becomes much simpler, as you obviously don't have to deal with different types.
+
+For integers, you could just a sensibly large integer, e.g. 64-bit and always serialize only into that. In case you want to save bytes, you can use variable sized integers like [LEB128].
+
+For floats the only sensible way is using IEEE-754 double precision float only. They are well supported by almost all programming languages.
+
+
+Problems with JavaScript
+------------------------
+
+Creating a canonical representation for numbers is possible when you distinguish between integers and floats. The IPLD Data Model has that property, hence it's not a problem designing a Codec that has a canonical representation of numbers. Though, there is the problem with JavaScript. Currently, most (all?) IPLD Data Model implementations work with native JavaScript types without any wrappers around them. The problem is that historically JavaScript only has a [`Number`] type, which is always a 64-bit IEEE-754 float. You cannot distinguish between `4251.00` and `4251`. Both are always floats.
+
+This means you can't really round-trip Data Model encodings in JavaScript. It looses the type information whether something was an integer as soon as it becomes a native `Number`. Possible solutions are using wrapper classes (we do the same in other programming language implementations like Go or Rust) or you leverage the recently introduced [`BigInt`] type.
+
+
+Thanks
+------
+
+Thanks [@mikeal] for making me put more thought into this and [@bobbl] for making me realize that most of the difficulties were in fact JavaScript related.
+
+
+[@vmx]: https://github.com/vmx
+[IPLD Data Model]: https://specs.ipld.io/data-model-layer/data-model.html
+[different encoding between JavaScript and Go when numbers are integers]: https://github.com/ipld/interface-ipld-format/issues/9#issuecomment-431029329
+[converting from JSON to CBOR]: https://tools.ietf.org/html/rfc7049#section-4.2
+[DAG-CBOR]: https://specs.ipld.io/block-layer/codecs/dag-cbor.html
+[`0.199951171875`]: https://float.exposed/0x3e4cc000
+[Integer]: https://specs.ipld.io/data-model-layer/data-model.html#integer-kind
+[Float]: https://specs.ipld.io/data-model-layer/data-model.html#float-kind
+[canonical representation]: https://tools.ietf.org/html/rfc7049#section-3.9
+[LEB128]: https://en.wikipedia.org/wiki/LEB128
+[binary IEEE-754 floating point numbers]: https://en.wikipedia.org/wiki/IEEE_754
+[`Number`]: https://developer.mozilla.org/en-US/docs/Glossary/Number
+[`BigInt`]: https://developer.mozilla.org/en-US/docs/Glossary/BigInt
+[@mikeal]: https://github.com/mikeal
+[@bobbl]: https://github.com/bobbl


### PR DESCRIPTION
This is an exploration report about how to serialize IPLD Data Model numbers
into bytes and back.

That report got very different from what I originally thought (which is great). It
got way simpler as all the problems I had are just due to JavaScript ;)