### PR TITLE
DAG-JSON: be more specific about numbers

### DIFF
--- a/block-layer/codecs/dag-json.md
+++ b/block-layer/codecs/dag-json.md
@@ -22,7 +22,7 @@ All kinds of the IPLD Data Model except Bytes and Link are supported natively by
 
 #### Numbers
 
-Numbers are a special case. JSON only has a single number type, though many dynamically typed languages (e.g. Python, Ruby, PHP) distinguish between integers and floats when parsing JSON. A number consisting only of digits is parsed as integer, if it contains a dot, it's parsed as a float. In DAG-JSON the same method is used to represent integers and floats.
+Numbers are a special case. JSON only has a single number type, though many dynamically typed programming languages (e.g. Python, Ruby, PHP) distinguish between integers and floats when parsing JSON. A number consisting of an optional leading sign and only digits is parsed as integer, if it contains a decimal point, it's parsed as a float. In DAG-JSON the same method is used to represent integers and floats.
 
 Contrary to popular belief, JSON as a format supports Big Integers. It's only
 JavaScript itself that has trouble with them. This means JS implementations

--- a/block-layer/codecs/dag-json.md
+++ b/block-layer/codecs/dag-json.md
@@ -20,9 +20,14 @@ producing the same data end up with matching block hashes.
 
 All kinds of the IPLD Data Model except Bytes and Link are supported natively by JSON.
 
+#### Numbers
+
+Numbers are a special case. JSON only has a single number type, though many dynamically typed languages (e.g. Python, Ruby, PHP) distinguish between integers and floats when parsing JSON. A number consisting only of digits is parsed as integer, if it contains a dot, it's parsed as a float. In DAG-JSON the same method is used to represent integers and floats.
+
 Contrary to popular belief, JSON as a format supports Big Integers. It's only
 JavaScript itself that has trouble with them. This means JS implementations
-of DAG-JSON can't use the native JSON parser and serializer.
+of DAG-JSON can't use the native JSON parser and serializer if integers bigger
+than `2^53 - 1` should be supported.
 
 ### Other kinds
 


### PR DESCRIPTION
The IPLD Data Model distinguishes between integers and floats,
so should DAG-JSON. The easy way is to do what popular dynamically
typed programming languages are doing. If the number only contains
digits, it's an integer, if it contains a decimal point, it's a
float.

This PR was triggered by my exploration report about numbers [1],
where I realized that there are also underspecified things when
parsing DAG-JSON as input.

[1]: https://github.com/ipld/specs/blob/19e572e4f0b71ed89b5eb4ea3132a1398cb96c05/design/history/exploration-reports/2020.10-data-model-numbers-and-codecs.md