### PR TITLE
hashmap: switch default hashAlg to SHA2-256

### DIFF
--- a/data-structures/hashmap.md
+++ b/data-structures/hashmap.md
@@ -255,7 +255,7 @@ These defaults are descriptive rather than prescriptive. New implementations may
 
 ### `hashAlg`
 
-* The default supported hash algorithm for writing IPLD HashMaps is the x64 form of the 128-bit [MurmurHash3](https://github.com/aappleby/smhasher) (identified by the multihash name ['murmur3-128'](https://github.com/multiformats/multicodec/blob/master/table.csv)). Note the x86 form will produce different output so should not be confused with the x64 form. Additionally, [some JavaScript implementations](https://cimi.io/murmurhash3js-revisited/) do not correctly decompose UTF-8 strings into their constituent bytes for hashing so will not produce portable results.
+* The default supported hash algorithm for writing IPLD HashMaps is SHA2-256 (identified by the multihash multicodec code `0x12`).
 * Pluggability of hash algorithms is encouraged to allow users to switch switch if their use-case has a compelling reason. Such pluggability requires the supply of an algorithm that takes Bytes and returns Bytes. Users changing the hash algorithm need to be aware that such pluggability restricts the ability of other implementations to read their data since matching hash algorithms also need to be supplied on the read-side.
 
 ### `bitWidth`
@@ -285,11 +285,6 @@ Future iterations of this specification may explore:
  * Default hash algorithm(s) outputting a larger number of bits (e.g. a cryptographic hash function such as SHA2-256).
  * Resetting the `index` calculation to take bits from the start of the hash once maximum-depth is reached, allowing or theoretically infinite depth data structures.
  * Allowing flexibility in `bucketSize` at maximum-depth nodes.
-
-### Hash algorithm
-
-* The use of MurmurHash3 x64 128-bit needs further research and modelling. There may be more appropriate default algorithms for the IPLD HashMap with more optimal characteristics (speed, randomness, suitability for a web environment, etc.).
-* There may arise a demonstrated need to encode a nonce or key in the root block to support keyed hash algorithms.
 
 ### Buckets
 


### PR DESCRIPTION
I kind of want to see some performance numbers on this and am tempted to add back in Murmur as an optional but explain the reasons why you might choose one over the other. Jeromy said (regarding this switch that Filecoin made) that SHA2-256 was a bit faster than Murmur on the CPUs that Filecoin has been focusing on (which have SHA2 instructions). But for JavaScript, the delta could be quite large in the other direction but I just don't know. Certainly if you want a cryptographically secure HAMT then go SHA2-256 ... and maybe a secure default is something we should be shipping anyway because these kinds of choices are nuanced—hash collision attacks are a consistent feature of programs and runtimes and we don't seem to be getting better at identifying where they are likely to show up, maybe we do our users a favour by opting for secure by default.