### PR TITLE
Add exploration report about selector syntax

### DIFF
--- a/design/history/exploration-reports/2020.02-selector-syntax.md
+++ b/design/history/exploration-reports/2020.02-selector-syntax.md
@@ -1,0 +1,792 @@
+
+#239: Add initial specification for selector syntax. (closed)
+-------------------------------------------------------------
+Opened 2020-02-06T22:53:50Z by creationix, closed 2020-10-08T21:10:58Z
+
+This is a proposal for a selector syntax that closely models the semantics already in the IPLD format of selectors.  The rational and constraints for the design are included in the documents as well as many examples and hopefully enough description of lexing/parsing behavior to make it unambiguous.
+
+I would love feedback on what you like about this, what drives you crazy, and hopefully find out if this is a good direction.
+
+
+Files
+-----
+`selectors/selector-syntax.md`
+
+Specification: IPLD Selectors Syntax
+=============================
+
+**Status: Prescriptive - Draft**
+
+Introduction
+------------
+
+### Motivation - What is Selectors Syntax
+
+*Prerequisites: [Selectors](selectors.md).
+
+IPLD Selectors are represented as IPLD data nodes.  This is great for embedding them in a structured way, but authoring them or viewing them in this format isn't the easiest.  This syntax provides a textual DSL for reading/writing selectors in a more text friendly format.
+
+Tooling can be used to convert between formats and even various styles optimized for the use-case at hand.
+
+#### URL Friendly
+
+Selector syntax should embed easily inside URLs.
+
+This means where possible, this syntax restricts itself to the characters that can be embedded in URLs without needing to escape them. This means this subset of ASCII:
+
+```js
+[ '!', "'", '(', ')', '*', '-', '.', '0', '1',
+  '2', '3', '4', '5', '6', '7', '8', '9', 'A',
+  'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+  'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+  'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '_', 'a',
+  'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+  'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
+  't', 'u', 'v', 'w', 'x', 'y', 'z', '~']
+```
+> 
+> ---
+> 
+> #### (2020-02-08T18:07:01Z) ribasushi:
+> "Easy embedding inside URLs" implies "easy visual skimming" ( perhaps with some initial training needed, just like e.g. regular expressions ). Assuming a person reading this is proficient: are we comfortable with a case sensitive, visually-collidable character set?
+> 
+> I am not particularly leaning one way or the other, but rather am bringing the point up for discussion .
+> 
+> ---
+> 
+> #### (2020-02-10T18:33:03Z) creationix:
+> This is certainly something we can use as an added constraint to consider when choosing the characters used for short form.  Currently, it only uses `f`, `i`, `r`, `u`, `c`, `F`, `*`, `.`, and `~`.
+> 
+> The listing of url safe characters is more of a technical constraint about what ASCII characters can be embedded in url components without needing to be escaped.
+
+This also also means it needs to be as terse as possible and not contain whitespace of any kind.
+
+For example, this selector simulates a git shallow clone by recursively walking commit parents up to depth 5 and walking all of the tree graphs for each.
+
+```ipldsel
+# Starting at the commit block.
+R5f'tree'Rn*~'parents'*~
+```
+
+#### Human Friendly
+
+Selector syntax should be easy to read/author by humans.
+
+This means it should be terser than the JSON or YAML representations of the IPLD data, but still verbose enough to have meaningful structure and keywords/symbols.
+> 
+> ---
+> 
+> #### (2020-03-02T03:49:28Z) rvagg:
+> minor style suggestion: collapse these two paragraphs into a bullet-point list hanging off the first sentence:
+> 
+> > ... easy to read/author by humans. This means it should:
+> > * Be terser ...
+> > * Allow flexibility ...
+
+This means it should allow flexibility with whitespace as well as allowing optional symbols and annotations to make structure easier to see visually.
+
+The exact same selector for git shallow clone from above can also be written in the following style: (This is not another mode, it's the same syntax):
+
+```ipldsel
+recursive(limit=5
+  fields(
+    'tree'(
+      recursive(limit=none
+        all(recurse)
+      )
+    )
+    'parents'(
+      all(recurse)
+    )
+  )
+)
+```
+
+Examples
+--------
+
+### Deeply Nested Path
+
+Based on [this example](example-selectors.md#deeply-nested-path).
+
+A selector to extract the year:
+
+#### Human Readable Style
+
+This is the default style for human interfacing.  It has clear structure and descriptive keywords.
+
+```ipldsel
+fields('characters'(
+  fields('kathryn-janeway'(
+    fields('birthday'(
+      fields('year'(match))
+    ))
+  ))
+))
+```
+
+#### URL Embeddable Style
+
+This is the default style for maximum terseness.  It minifies everything possible.
+
+```ipldsel
+f'characters'f'kathryn-janeway'f'birthday'f'year'.
+```
+
+### Getting a certain number of parent blocks in a blockchain
+
+This is based on [this sample](example-selectors.md#getting-a-certain-number-of-parent-blocks-in-a-blockchain).
+
+#### Parents Without Recursion
+
+Direct and simple path traversal:
+
+```ipldsel
+# Long Form
+fields('parent'(
+  fields('parent'(
+    fields('parent'(
+      fields('parent'(
+        fields('parent'(
+          match
+        ))
+      ))
+    ))
+  ))
+))
+
+# Short Form
+f'parent'f'parent'f'parent'f'parent'f'parent'.
+```
+
+#### Parents Using Recursion
+
+```ipldsel
+# Long Form
+recursive(limit=5
+  fields('parent'(
+    recurse
+  ))
+)
+
+# Short Form
+R5f'parent'~
+```
+
+### Getting changes up to a certain one
+
+Based on [this example](example-selectors.md#getting-changes-up-to-a-certain-one).
+
+```ipldsel
+# Long Form
+recursive(
+  limit=100
+  fields(
+    'prev'(recurse)
+  )
+  stopAt=... # Conditions are not specified yet
+)
+
+# Short Form
+R100f'prev'~... # Conditions are not specified yet
+```
+
+### Retrieving data recursively
+
+Based on [this example](example-selectors.md#retrieving-data-recursively).
+
+The following selector visits all `links` and matches all `data` fields:
+
+```ipldsel
+# Long Form
+recursive(limit=1000
+  fields(
+    'data'(match)
+    'links'(
+      all(
+        fields('cid'(
+          recurse
+        ))
+      )
+    )
+  )
+)
+
+# Short Form
+R1000f'data'.'links'*f'cid'~
+```
+
+Syntax Specification
+--------------------
+
+Selectors Syntax is defined as a textual projection of the Selector AST and thus does not contain any of its own runtime semantics.
+
+### Long and Short Keywords
+
+Each selector type has both long and short names that can be used interchangeably as follows:
+
+- Matcher can be `match` or `.`
+- ExploreAll can be `all` or `*`
+- ExploreFields can be `fields` or `f`
+- ExploreIndex can be `index` or `i`
+- ExploreRange can be `range` or `r`
+- ExploreRecursive can be `recursive` or `R`
+- ExploreUnion can be `union` or `u`
+- ExploreConditional can be `condition` or `c`
+- ExploreRecursiveEdge can be `recurse` or `~`
+
+This mode-less flexibility, combined with tools to automatically translate in bulk between styles, makes it possible for a single syntax to work well for both human and url embedding use cases.
+
+### Whitespace is Ignored
+
+Whitespace is completely ignored by the parser except for inside quoted strings.
+
+Line comments are also ignored even if they contain things that look like quoted strings
+
+### Parentheses are Usually Optional
+
+Parentheses annotate structure and are sometimes required for ambigious cases such as unions which contain an arbitrary number of selectors or selectors with optional parameters of conflicting types.
+
+For example `union(union match match)` is interpreted as `union(union(match match))` and not `union(union(match) match)` because in the first, the last match will be part of the inner union and not the outer union.  When minimizing, some parentheses might be kept to preserve semantics.
+
+- `uu..` -> `{ selector: { '|': [ { '|': [ { '.': {} }, { '.': {} } ] } ] } }`
+- `uu(.).` -> `{ selector: { '|': [ { '|': [ { '.': {} } ] }, { '.': {} } ] } }`
+
+The best practice (and what the default formatting styles will enforce) is for human readable selectors to use parentheses liberally while URL embedding style will only contain the required ones.
+> 
+> ---
+> 
+> #### (2020-02-08T18:23:01Z) ribasushi:
+> I am not sure I fully understand this / the motivation for `R`...`~` and other scope-pairs is not entirely clear. Could you elaborate  "even harder" why you didn't go with a more traditional balanced pair of characters e.g. `(` `)` ? Especially jarring is the discrepancy of doing couple paragraphs down:
+> ```
+> # URL Embeddable
+> R(5...)
+> ```
+> 
+> ---
+> 
+> #### (2020-02-10T18:03:18Z) creationix:
+> I'm not sure what you mean by pairing up `R` and `~`.  They are not necessarily balanced; there could technically be multiple recursive edges inside a single recursive node.  It's not a scope pair, but rather two distinct node types in the selector AST that happen to relate to eachother.
+> 
+> Also I use `(` and `)` already in the syntax to help with forcing parameters to the correct nodes.
+> 
+> ---
+> 
+> #### (2020-02-10T19:56:55Z) ribasushi:
+> > They are not necessarily balanced; there could technically be multiple recursive edges inside a single recursive node.
+> 
+> This might **very** well be my lack of understanding of the problem domain. Let's cover this during the ipld meet if time permits.
+> 
+> ---
+> 
+> #### (2020-02-10T21:58:24Z) ribasushi:
+> We chatted about this a bit more - I now understand what was meant by the above quote. I withdraw the question about balanced parens ;)
+
+### Parameters can be Named
+
+Parameters can usually be inferred by their contextual position, but there are some cases where it's ambigious and needs to be specified.  There are more cases where it's good to annotate them for human clarity.
+
+For example, `recursive` has two required parameters and a 3rd optional one.
+
+```ts
+recursive(sequence: Selector, limit: int, stopAt?: Condition)
+```
+
+Written verbosely with parentheses, named parameters, and whitespace, it looks like this:
+
+```ipldsel
+recursive(
+    limit=5
+    sequence=...
+)
+```
+
+Depending on the context, we could omit the parentheses because the optional `stopAt` parameter is of type `Condition` and the parser likely expects something else after this node.
+> 
+> ---
+> 
+> #### (2020-03-02T04:26:59Z) rvagg:
+> so there aren't any selector forms with possibly ambiguous lengths so predicting a `stopAt` in the shortened selector syntax should be straightforward?
+> I see `Matcher` in the selector schema also has two optional fields, `onlyIf` and `label`, could these get in the way?
+> 
+> ---
+> 
+> #### (2020-03-08T03:02:04Z) creationix:
+> It's hard to say.  This is why I'm implementing syntax parsers.  So far I've not come across any concrete use cases where the parentheses are actually needed.
+
+Also we don't need to annotate `limit=` or `sequence=` since both are non-optional, and unique types.  Notice that the order doesn't matter and we can put `limit` before `sequence` because of unambigious types.
+
+Best practice is to annotate `limit`, but not `sequence` for human readable, and omit both for URL form.
+
+```ipldsel
+# Human Readable
+recursive(limit=5 ...)
+# URL Embeddable
+R5...
+```
+
+### Literal Values
+
+Some of the selectors accept literal values as parameters.  These are currently `String`, `{String:Selector}`, and `Int`.
+
+#### Integers
+
+Integers can be encoded using base 10 with optional leadin sign:
+
+```
+123 # Decimal
+-123 # Negative decimal
+```
+
+#### Strings
+
+Strings are quoted using single quote.  They can contain any characters including newlines and unicode characters.  The following characters can be escaped using backslash (`\`) followed by a special character.  If the backslash is followed by a character not in the list, it's considered a syntax error.
+
+- \b  Backspace (ascii code 08)
+- \f  Form feed (ascii code 0C)
+- \n  New line
+- \r  Carriage return
+- \t  Tab
+- \'  Single quote
+- \\  Backslash character
+
+```
+'Hello World'
+'It\'s a lovely day'
+'Multiline
+strings'
+'Multiline\nstrings'
+```
+
+#### Maps
+
+We need to be able to encode the keys for the `fields` selector.  This is done using multiple string literals followed by nested contents.
+
+```ipldsel
+fields(
+  'foo'(...)
+  'bar'(...)
+)
+```
+
+### Whitespace and Comments
+
+Comments are allowed in this syntax and will be preserved by auto-formatters when possible, but will be stripped when converting to URL style and are not included in the IPLD representation of the selector.
+
+A comment starts at `#` and ends at end of line.
+
+Parser Specification
+--------------------
+
+# Initial Stripping
+
+The parser must act as is there was an initial pass that removed all whitespace not inside strings and all line comments.
+
+```ipldsch
+# This is a comment 'this is not a string'
+'This # is # a string' this is normal
+this is also normal
+
+# Keywords get merged
+hello world
+helloworld
+
+# Comments get stripped
+'a string' # and comment
+'a string'
+
+# Strings inside comments are still comments
+empty # a comment with a 'string'
+empty
+```
+
+### Identifier Tokenization
+
+The parser knows a fixed set of built-ins to look for.  This is the long and short forms of the selectors and other built-ins.  To keep the specification simple, text is semantically tokenized by sorting all the identifiers longest first and trying each one in that order till one matches.
+
+```ipldsel
+# This will match `fields` first and not even try `f`.
+fields...
+```
+
+### Parentheses and Parse Order
+
+Arguments/parameters are consumed greedily by the innermost consumer.  If the type doesn't match what it is looking for, then it is closed and the next in the stack gets a shot.  If we run out of consumers and the value is unmatched, it's a syntax error.  For example:
+
+```ipldsel
+fields 'fieldName' match
+```
+
+First we parse `fields`. This expects `{String:Selector}`, which to the parser, is a stream of alternating `String` and `Selector` tokens.  We put this on the stack and look at the next value.  It's a `String` which has no children.  The consumer on the top of the stack is looking for a string, so we give it to it.  Then we read the next.  It's a `match` which also has no children.  The `fields` on the stack is now looking for a `Selector` which this qualifies as, so it gets consumed next.
+
+After that we reach the end of the stream and pop everything off the stack.  Any consumer that still lacks a required parameter is now a syntax error.
+
+We could have added parentheses to this, but they were not needed since the default parsing interpretation is what we wanted.
+
+```ipldsel
+# This is the same as above when parsed.
+fields('fieldname'(match))
+```
+
+When parentheses are added, they can override the default greedy behavior in some otherwise ambigious cases.  Again, the example ``union union match match`` is not `union(union(match) match)` but is `union(union(match match))` because the innermost union gets to greedily match first.  Extra parentheses can be added as `union union(match) match)`, or in short form`uu(.).` vs `uu..`
+
+Known issues
+------------
+
+- Note that the status of this document is "Draft"!
+- The "Condition" system is not fully specified -- it is a placeholder awaiting further design.
+- The description of the lexing and parsing algorithm should be sufficient for unambiguous parsing, but more formal consideration is strongly recommended including tools to test for regressions as we add to this language.
+
+Other related work
+------------------
+
+### Implementations
+
+None yet.
+
+### Design History
+
+None yet.
+
+---
+
+Comments
+--------
+
+#### (2020-02-07T17:01:27Z) vmx:
+Wow, that is really a good read. My comments are only in regards to typos the rest sounds great.
+
+
+---
+
+#### (2020-02-08T18:24:18Z) ribasushi:
+Marking "request changes" as stand-in for "request discussion". Will d another pass over this once the first two pieces are clarified
+
+Awesome work as a whole!
+
+
+---
+
+#### (2020-02-08T18:29:40Z) warpfork:
+I have no objections to this, I think :)
+
+I'm also not really reviewing for ergonomics though, as I feel ill suited to do so without an application in my mind's eye, which I'm pretty sparse on.  And thus, "no objections" is about the greenest light I'm likely to give, if that makes sense. :P
+
+
+---
+
+#### (2020-02-10T18:43:57Z) creationix:
+After spending a day implementing a full parser, I've discovered the white-space rules are more interesting than I initially thought.  The design goal was to make white-space 100% irrelevant to the parser.  Most programming languages claim to not have significant white-space, but that's not entirely true for any real language.
+
+The first exception obviously is white-space within strings needs to be preserved.  This is easy enough, I simply turn off white-space stripping when within quoted sections.
+
+The second case is one you typically don't realize.  Most languages use white-space as token separators.  For example:
+```
+# Escaped quotes
+'This is ''one'' string with escaped quotes.'
+# Escaped quotes or two strings?
+'is this one string?' 'or two strings?`
+```
+
+The parsing of the second example *depends* on that space being between the two string literals.  If we really ignore white-space, then it should parse the same if the space is removed.
+
+Currently, this syntax really means it when it says no white-space, and the second will be a single string.
+
+Another example is identifiers.  In most languages `foo bar` is clearly two identifiers while `foobar` is one.  In this language, we ignore the space entirely and both look identical to the parser. It needs other clues to know where one identifier/selector starts and where another ends.  This is accomplished by the language having a fixed set of identifiers and careful design to make sure that there is never ambiguity.
+
+For example we should avoid having a `foo` selector with short form `f` if there is also another selector who's short form is `o`.  A developer may write `foo` and we might interpret it as `f`, `o`, `o`, or they might write `f o o` and we interpret it as `foo`.
+
+This spec does specify which it should be (it would be always `foo` because it's longer).  But we also want to avoid these situations whenever possible since humans are not compilers and may have different expectations since most/all existing languages don't really ignore white-space.
+
+
+---
+
+#### (2020-02-10T21:43:53Z) creationix:
+@warpfork One solution to the potential confusion with merged identifiers would be to preserve the white-space as tokens and tell the parser about them.  But the problem with this is it would require those spaces to be preserved in compact mode.  This could almost double the length of minimized version and include lots of spaces which can sometimes be problematic in URLs.
+
+I'll consider it further though.
+
+
+---
+
+#### (2020-02-10T22:10:48Z) warpfork:
+Definitely meant my remark on that as a "2 cents".  You've probably already thought about it much more than I have.
+
+
+---
+
+#### (2020-02-17T22:46:15Z) creationix:
+The initial lexer implementation is now done.  The description in the spec for parsing out identifiers seems to be working. https://github.com/creationix/sel-parse-zig/blob/887c3628e11b4ff751e68a9ade4c18a9bf4daf25/src/lexer.zig
+
+In particular, there is a hard coded list of identifiers expected here:
+```zig
+// Sorted by longest first, then lexical within same length.
+const identifiers = .{
+"condition",
+"recursive",
+"recurse",
+"fields",
+"index",
+"match",
+"range",
+"union",
+"all",
+".",
+"*",
+"~",
+"c",
+"f",
+"i",
+"r",
+"R",
+"u",
+};
+```
+And then parsing those ends up being quite straightforward.
+```zig
+// Tokenize Identifiers
+inline for (identifiers) |ident| {
+var matched = true;
+var i: u32 = 0;
+while (i < ident.len) {
+if (i >= input.len or ident[i] != input[i]) {
+matched = false;
+break;
+}
+i += 1;
+}
+if (matched) return Token{ .id = .Identifier, .slice = input[0..i] };
+}
+```
+
+
+---
+
+#### (2020-02-17T23:08:55Z) creationix:
+To get an idea of what the lexer tokens look like, this is the output of the following:
+
+```ipldsel
+recursive(limit=5
+fields(
+'tree'(
+recursive(
+all(recurse)
+)
+)
+'parents'(
+all(recurse)
+)
+)
+)
+```
+
+```zig
+0       Id.Identifier   9B      `recursive`
+9       Id.Open 1B      `(`
+10      Id.Unknown      1B      `l`
+11      Id.Identifier   1B      `i`
+12      Id.Unknown      1B      `m`
+13      Id.Identifier   1B      `i`
+14      Id.Unknown      2B      `t=`
+16      Id.Decimal      1B      `5`
+17      Id.Whitespace   3B      `
+`
+20      Id.Identifier   6B      `fields`
+26      Id.Open 1B      `(`
+27      Id.Whitespace   5B      `
+`
+32      Id.String       6B      `'tree'`
+38      Id.Open 1B      `(`
+39      Id.Whitespace   7B      `
+`
+46      Id.Identifier   9B      `recursive`
+55      Id.Open 1B      `(`
+56      Id.Whitespace   9B      `
+`
+65      Id.Identifier   3B      `all`
+68      Id.Open 1B      `(`
+69      Id.Identifier   7B      `recurse`
+76      Id.Close        1B      `)`
+77      Id.Whitespace   7B      `
+`
+84      Id.Close        1B      `)`
+85      Id.Whitespace   5B      `
+`
+90      Id.Close        1B      `)`
+91      Id.Whitespace   5B      `
+`
+96      Id.String       9B      `'parents'`
+105     Id.Open 1B      `(`
+106     Id.Whitespace   7B      `
+`
+113     Id.Identifier   3B      `all`
+116     Id.Open 1B      `(`
+117     Id.Identifier   7B      `recurse`
+124     Id.Close        1B      `)`
+125     Id.Whitespace   5B      `
+`
+130     Id.Close        1B      `)`
+131     Id.Whitespace   3B      `
+`
+134     Id.Close        1B      `)`
+135     Id.Whitespace   1B      `
+`
+136     Id.Close        1B      `)`
+```
+
+
+---
+
+#### (2020-03-02T04:54:53Z) rvagg:
+I really like how the two forms are really just one form, with shortenings (and no comments for URL form), but we're trading that against ease of implementation though, so every environment that needs to be able to use these would need to have a custom parser written. I doesn't _seem_ difficult, but it's worth noting as we expand our language support (Go, JS and now Rust, but also Filecoin is using selectors and being implemented in C++ and maybe others too and this might be something they want at some point) that we're making that exchange.
+
+
+---
+
+#### (2020-03-08T03:07:16Z) creationix:
+@rvagg FWIW, I'm working on two concurrent implementations.  One in vanilla JS and one using zig-lang which can be compiled to webassembly or a C ABI library for use in virtually any language.  I plan to tweaking this spec with my findings from the two parsers to ensure it's not more difficult than it needs to be.
+
+
+---
+
+#### (2020-03-14T16:23:40Z) creationix:
+So while implementing multiple versions of the parser, I'm getting more and more convinced this spec needs to be more automated and formalized.  I'm now spiking on generating a syntax grammer that can be automatically derived from the selector schema directly.  The design will still be similar to what's proposed here, but it should be more consistent and less hand-crafted to make tooling across the board easier.
+
+
+---
+
+#### (2020-03-16T14:23:39Z) creationix:
+Ok, the JS parser can now correctly compile all the sample selectors in this spec.  The new approach worked well.  Basically, I load the existing IPLD Schema for selectors and generate a parser from that.  In order to match the proposed syntax, the parser generator accepts a list of "aliases" for various types.  For example, this is the line in JS that generates the selector syntax parser:
+```js
+const schema = schemaParse(readFileSync(`${__dirname}/selectors.ipldsch`, 'utf8'))
+
+const parseSelectorEnvelope = makeParser(schema, "SelectorEnvelope", {
+Matcher: ['match', '.'],
+ExploreAll: ['all', '*'],
+ExploreFields: ['fields', 'f'],
+ExploreIndex: ['index', 'i'],
+ExploreRange: ['range', 'r'],
+ExploreRecursive: ['recursive', 'R'],
+ExploreUnion: ['union', 'u'],
+ExploreConditional: ['condition', 'c'],
+ExploreRecursiveEdge: ['recurse', '~'],
+RecursionLimit_None: ['none', 'n'],
+})
+```
+
+The types mentioned are existing in the schema, I'm creating a semi-automated DSL by specifying the entry point and long and short keywords for some types.
+
+Note that this library could be used to create a DSL for *any* IPLD data structure that has a schema.
+
+
+---
+
+#### (2020-03-16T15:10:36Z) creationix:
+I found a case where the parentheses are significant and can't always be removed when converting to short form.  Consider the following selector:
+```sh
+union(
+union(
+match
+)
+match
+)
+```
+
+Since`union` (aka  `ExploreUnion`) contains a list (aka `[Selector]`), it consumes an arbitrary number of selectors.  If the parentheses are removed, the two matches will be put under the inner union.  Therefore the short form of this is:
+
+```sh
+# Correct short form
+uu(.).
+
+# Wrong short form
+uu..
+```
+
+We could keep it simple and say the minimizer always preserves parentheses when encoding a list.  I don't even know of any real world use cases that use `ExploreUnion` and would love to see the actual use cases.  A smarter minimizer could do some basic analysis to know when the parentheses are required and only include them then.
+
+
+---
+
+#### (2020-03-16T15:21:19Z) creationix:
+Another case where they are required is labeled matchers inside of fields.
+```sh
+# Fields with labels
+fields(
+'with-label'(
+match('label')
+)
+'without-label'(
+match
+)
+)
+
+# Properly Minimized
+f'with-label'(.'label')'without-label'.
+
+# Another Properly Minimized
+f'with-label'.('label')'without-label'.
+
+# Broken minimized
+f'with-label'.'label''without-label'.
+```
+
+This brings up another question about normalization of minimized form.  Are we OK with there being multiple correct short forms?  Does it matter?
+
+
+---
+
+#### (2020-03-16T15:59:25Z) creationix:
+@rvagg, you were right!
+
+Strings are problematic too.  The less common escaping method used for strings (two single quotes) works, but it also introduces cases where multiple token are merged.  For example, consider the following:
+
+```sh
+fields
+'foo'
+match
+label='blue'
+'bar'
+match
+```
+
+This currently breaks because the `'blue'` label and the `'bar'` field are merged into a single label containing `"blue'bar"`.
+
+```sh
+Sample:
+
+fields
+'with-label'
+match
+label='my-label'
+'another-field'
+match
+
+
+SyntaxError: "fields'foo'matchlabel='blue''bar'match"
+^ Unexpected extra syntax at 33
+```
+
+I propose we switch to a more traditional string syntax with backslash escaping.  It will add some bloat when url encoding, but overall should be an improvement.
+
+
+---
+
+#### (2020-03-17T06:15:41Z) rvagg:
+> This brings up another question about normalization of minimized form. Are we OK with there being multiple correct short forms? Does it matter?
+
+I don't know specifically for this but we keep on finding cases elsewhere where we don't have one-single-way and this being a problem. I don't know how that would show up here, but maybe if someone chose to encode a selector string rather than a full selector as per schema then having more than one way to say the same thing might be a problem. There's a lot of byte-shavers around that will look at this work and look at the full selector schema and opt for a short string form.
+
+Would it be a big deal to make a _must be simplest accurate representation_ rule that would give us one-single-way?
+
+Re `ExploreUnion`, it's a selection strategy that is only useful when you have more than one selector to use isn't it? For practical purposes you should always have >1 item in the list, making parens always necessary and your example overly simple. There are going to be cases of poorly crafted selectors that misuse it, but that shouldn't be the normal case.
+
+
+---
+
+#### (2020-10-08T21:10:58Z) mikeal:
+We’ve learned a lot from this but we’re not quite sure how we want to handle simplified string representations for selectors and paths. Closing for now.
+
+
+---
+
+#### (2020-10-08T21:10:58Z) Closed by mikeal

--- a/design/history/exploration-reports/2020.02-selector-syntax.md
+++ b/design/history/exploration-reports/2020.02-selector-syntax.md
@@ -1,3 +1,9 @@
+Selector Syntax
+===============
+
+This exploration report was originally [Pull Requst 239](https://github.com/ipld/specs/pull/239). It got converted [via script](https://github.com/vmx/export_issues) into an exploration report in order to preserve all the useful information it contains.
+
+---
 
 #239: Add initial specification for selector syntax. (closed)
 -------------------------------------------------------------


### PR DESCRIPTION
This exploration report was originally a PR. It got converted into an
exploration report in order to preserve all the useful information it
contains.

It contains a few comments that a not necessarily needed, but the nice
thing is that my script created this output without manual interference.

If someone feels like cleaning things up, feel free to do so.