### PR TITLE
Add exploration report about a new version of DAG-JSON

### DIFF
--- a/design/history/exploration-reports/2019.06-new-version-dag-json.md
+++ b/design/history/exploration-reports/2019.06-new-version-dag-json.md
@@ -1,0 +1,238 @@
+
+#129: Proposal: new version of dag-json (open)
+----------------------------------------------
+Opened 2019-06-11T03:53:16Z by mikeal
+
+This spec change would resolve the outstanding issue of `dag-json` not being able to represent the “/“ key.
+
+Since “/“ is already reserved, we use that key for the version definition, which makes this new version backwards compatible with all of the existing `dag-json` data.
+
+This change would also set up `dag-json` to store data outside of the actual node data, which could be used similar to how tags are used in cbor or for something like https://github.com/ipld/js-generics/issues/3
+
+
+Files
+-----
+`block-layer/codecs/DAG-JSON.md`
+
+# Specification: DAG-JSON
+
+**Status: Descriptive - Final**
+
+DAG-JSON supports the full [IPLD Data Model](../data-model-layer/data-model.md).
+
+## Format
+
+### Simple Types
+
+All simple types except binary are supported natively by JSON.
+
+Contrary to popular belief, JSON as a format supports Big Integers. It's only
+JavaScript itself that has trouble with them. This means JS implementations
+of `dag-json` can't use the native JSON parser and serializer.
+
+### Version 0
+
+This is an old version of `dag-json` that reserved the `"/"` key in order to
+represent binary and link data types.
+
+#### Binary Type
+
+```javascript
+{"/": { "base64": String }}
+```
+
+#### Link Type
+
+```javascript
+{"/": String /* base encoded CID */}
+```
+
+### Version 1
+
+#### Format
+
+The internal data format is valid JSON but is **NOT** identical to the decoded
+node data codecs produce.
+> 
+> ---
+> 
+> #### (2019-06-11T10:33:10Z) daviddias:
+> I do not understand why this is necessary. Is there a place with the rationale to make JSON not JSON?
+> 
+> ---
+> 
+> #### (2019-06-11T20:16:25Z) mikeal:
+> Right now, we’re using a reserved key, `”/“`, for encoding links and binary. Several people think that key reservation is highly problematic because it means there are certain data sets you just can encode.
+> 
+> This change would fix that changing the internal block format. The format would **still* be valid JSON, it just wouldn’t have as close of a 1-to-1 match with the decoded form of the data.
+> 
+> However, this change may not be worth it. This PR is to show that we have a solution to the reserved key issue and that is what it would take to fix it.
+
+Example internal format:
+
+```javascript
+{ "/": { "_": 1 },
+```
+> 
+> ---
+> 
+> #### (2019-06-11T11:13:53Z) vmx:
+> Wouldn't it be simpler to just add a field called `version` and move `meta` and `data` to the top-level?
+> 
+> ---
+> 
+> #### (2019-06-11T20:17:34Z) mikeal:
+> “meta” and “data” *are* top level. using “_” was just to save space but we can do whatever we want.
+> 
+> ---
+> 
+> #### (2019-06-12T08:23:03Z) vmx:
+> Oh, sorry I missed that they are top-level.
+```javascript
+  "data": { "hello": "world", { "obj": { "array": [0, 0] } } },
+```
+> 
+> ---
+> 
+> #### (2019-06-11T11:10:07Z) vmx:
+> So those `[0, 0]` are placeholders? So if you want to encode `[CID, "some string"]` it would be `[0, "some string"]`?
+> 
+> ---
+> 
+> #### (2019-06-11T20:16:42Z) mikeal:
+> They are just placeholders to preserve the ordering of the array.
+> 
+> ---
+> 
+> #### (2019-06-12T08:21:54Z) vmx:
+> I'd use `null` for that, but that's a minor detail. Perhaps the example could be expended to `[null, "some string", null]` to make it clearer that there are place holders which are mixed with actual values.
+> 
+> ---
+> 
+> #### (2019-06-12T16:42:19Z) mikeal:
+> originally it was null but i went with 0 because null encoding is extra bytes :/
+```javascript
+  "meta": {
+    base64: [
+      [[ "key" ], "dmFsdWU="],
+```
+> 
+> ---
+> 
+> #### (2019-06-11T11:16:29Z) vmx:
+> I key see where those tuples come from. Why not using an "overlay object" with proper nesting as you did in your other dag-json experiment?
+> 
+> Is it because you could get the binary data/links without traversing a nested structure?
+> 
+> ---
+> 
+> #### (2019-06-11T20:19:57Z) mikeal:
+> If you recall, we considered that in a `dag-json` alternative proposal and the problem, which I think you ended up alerting me to, was how to represent sparse values in an array.
+> 
+> ---
+> 
+> #### (2019-06-12T08:23:54Z) vmx:
+> Right, that would be a lot of placeholders then.
+```javascript
+      [[ "obj", "key"], "dmFsdWU="],
+      [[ "obj", "array", 0], "dmFsdWU="]
+    ],
+    links: [
+      [["obj", "array", 1], "zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA"]
+    ]
+  }
+}
+```
+
+Decodes to:
+
+```javascript
+{ hello: 'world',
+  key: Buffer.from('value'),
+```
+> 
+> ---
+> 
+> #### (2019-06-11T11:24:50Z) vmx:
+> I would really prefer if we'd move to an Browser first approach and not using Node.js primitives:
+> 
+> ```JS
+> key: new TextEncoder().encode('value'),
+> ```
+> 
+> ---
+> 
+> #### (2019-06-11T20:21:48Z) mikeal:
+> it’s just not entirely clear to everyone that this does binary encoding. perhaps we should just move to psuedo-code, something like `Bytes(‘value’)`
+> 
+> ---
+> 
+> #### (2019-06-12T08:24:51Z) vmx:
+> That would work for me. I just don't want to give the impression it's a Node.js Buffer.
+```javascript
+  obj: {
+    array: [ Buffer.from('value'), new CID('zb2rhe5P4gXftAwvA4eXQ5HJwsER2owDyS9sKaQRRVQPn93bA')],
+    key: Buffer.from('value')
+  }
+}
+```
+
+---
+
+Comments
+--------
+
+---
+
+#### (2019-06-12T16:10:10Z) Stebalien:
+Is the motivation _just_ to support `/` keys? IMO, dag-json exists so users could read and write IPLD using JSON. I'm concerned this format looses that.
+
+If we _just_ want to support `/` in keys, we could use some form of escaping syntax. For full backwards compatibility, we could do something like `{"/": {"literal": foobar}}`. Alternatively, we can _probably_ allow escaping forward slash without breaking too much: `//` -> `/`.
+
+
+---
+
+#### (2019-06-12T16:49:15Z) mikeal:
+> IMO, dag-json exists so users could read and write IPLD using JSON. I'm concerned this format looses that.
+
+I’m a little confused by this use case, because the `dag-json` codec already isn’t `json`. If you want to take a block of existing `json` data you should just use a `json` codec (which we should implement since it would be trivial).
+
+If you want to take existing JSON data and add links to it, you’re going to have to use an encoding interface anyway and all of these details are invisible.
+
+Is there a case I’m missing where you want `dag-json` instead of `json` **and** you’re interacting directly with the block format?
+
+> Is the motivation just to support / keys?
+
+Yes, that’s the only thing we get out of this change. Using “/“ as a key will *still* be highly problematic for anyone using paths and selectors, but this would fix the issue at the codec level.
+
+I’m actually not too worried about “/“ being reserved in `dag-json` but other people seem to be. I opened this PR to show what it would take to fix the issue, given some people are concerned.
+
+
+---
+
+#### (2019-06-12T18:57:53Z) Stebalien:
+> I’m a little confused by this use case, because the dag-json codec already isn’t json. If you want to take a block of existing json data you should just use a json codec (which we should implement since it would be trivial).
+
+dag-json wasn't designed to be 100% compatible but still mostly compatible. I agree we should have a plain JSON format for users who just want JSON but the point of _this_ format was to provide a familiar, JSON-like format that mostly "just works" (i.e., you can link up existing JSON objects).
+
+
+---
+
+#### (2019-06-17T11:55:59Z) vmx:
+Another thing that might be worth keeping in mind. Having a format you can easily use as exchange format for tests: https://github.com/multiformats/rust-cid/pull/17#issuecomment-502395133
+
+
+---
+
+#### (2019-08-20T11:08:19Z) vmx:
+@mikeal We decided to put this into design history, but after having a closer look  I think the discussion can be easily be summed up. Instead of having it archived automatically I suggest that we create a proper exploration report like https://github.com/ipld/specs/blob/035683c97d0280de5e2d490822d63ad618a8acab/design/history/exploration-reports/2019.06-unixfsv2-spike-01.md. @mikeal if you think it's worth having it there, could you please create a new PR with that report?
+
+
+---
+
+#### (2019-10-02T10:27:07Z) Assigned to mikeal
+
+---
+
+#### (2020-10-08T21:19:39Z) mikeal:
+Closing as this was mostly informational. @vmx will use his script to create an exploration report for this.

--- a/design/history/exploration-reports/2019.06-new-version-dag-json.md
+++ b/design/history/exploration-reports/2019.06-new-version-dag-json.md
@@ -1,3 +1,9 @@
+New DAG-JSON
+============
+
+This exploration report was originally [Pull Requst 129](https://github.com/ipld/specs/pull/129). It got converted [via script](https://github.com/vmx/export_issues) into an exploration report in order to preserve all the useful information it contains.
+
+---
 
 #129: Proposal: new version of dag-json (open)
 ----------------------------------------------

--- a/design/history/exploration-reports/2019.06-new-version-dag-json.md
+++ b/design/history/exploration-reports/2019.06-new-version-dag-json.md
@@ -182,8 +182,6 @@ Decodes to:
 Comments
 --------
 
----
-
 #### (2019-06-12T16:10:10Z) Stebalien:
 Is the motivation _just_ to support `/` keys? IMO, dag-json exists so users could read and write IPLD using JSON. I'm concerned this format looses that.
 


### PR DESCRIPTION
This exploration report was originally a PR. It got converted into an
exploration report in order to preserve all the useful information it
contains.