### PR TITLE
Add exploration report for a schema listpair extension

### DIFF
--- a/design/history/exploration-reports/2020.10-schema-listpair-extension.md
+++ b/design/history/exploration-reports/2020.10-schema-listpair-extension.md
@@ -1,0 +1,169 @@
+Schema listpair extension
+=========================
+
+**Author**: Volker Mische ([@vmx])
+
+First of all, this idea wasn't mine, it came up during a conversation with [@ianopolous]. I also don't think it's a new idea, but I'm not aware that we've a written record of this.
+
+This idea is related to the discussion about the [IPLD Data Model] `String` kind should be defined, as 8-bit byte sequence or as sequence of Unicode characters. I get into details why it can help with that discussion as well at the end of the document. Though I encourage readers to read this exploration report without that issue in mind.
+
+
+The idea
+--------
+
+Currently the [IPLD Schemas] `Map` kind shares the same limitations in regards to the key kind as the Data Model `Map`s do. They can only be of kind `String`. There are applications where it would be convenient to be able to other kinds as well, for example the `Integer` kind.
+
+IPLD Schemas already support different representations for the `Map` kind. One of them is [`listpairs`]. This representation could be extended to support other kinds as well. A `Map` with `Integer` keys could look like that:
+
+```ipldsch
+type IntegerKeyedMap { Int: String } representation listpairs
+```
+
+Some data matching the `IntegerKeyedMap` Map (shown as JSON) is:
+
+```json
+[[16711680, "red"], [65280, "green"], [255, "blue"]]
+```
+
+
+Analysis
+--------
+
+### Other representations
+
+Giving the `listpairs` representation the power of having keys with arbitrary key, makes it a special case. The other representations won't work with it.
+
+So for example the default `map` representation with a definition like this
+
+```ipldsch
+type IntegerKeyedMap { Int: String }
+```
+
+would need to produce an error as IPLD Data Model `Map`s only support keys with the `String` kind.
+
+In also applies to the `stringpairs` representation. Though that representation has already constraints that they key as well as the value need to be representable as a Data Model `String` kind.
+
+The different representations would support these key value pairs:
+
+| Representation | Key      | Value    |
+| -------------- | -------- | -------- |
+| `stringpairs`  | `String` | `String` |
+| `map`          | `String` | any kind |
+| `listpairs`    | any kind | any kind |
+
+
+### Selectors
+
+Selectors operate on the Data Model and not on the Schema level. This means that making the proposed `listpairs` extension to the Schema `Map` kind won't change anything on the Selectors.
+
+Though this is not fully true. When thinking about Selectors, you also want to apply them to things that are expressed in the Schema, but is not necessarily reflected in the Data Model representation. An example are `Struct`s where you want to access something by the field name, even if its representation `tuple`.
+
+The same method can be applied to the extended `listpairs` representation for `Map`s. The Selector could be translated into a pure Data Model representation, or your implementations might have an abstraction to support iterating over such a different map representation.
+
+
+### Pathing
+
+Basic pathing is done in the Data Model, so no changes would be needed. In order to path over kinds other than strings, some more advanced pathing that is Schema aware would be needed. It needs to be determined whether this should be part of the basic pathing, the Selectors or something separate. Independent of this proposal, something similar would be needed in case pathing over `Struct`s should be supported (which I think should be).
+
+
+### Codecs
+
+Depending on the Codec, things can be similarly efficient as with Data Model `Map`s. Take CBOR as an example. Let's not think about the Data Model for a moment, but only about the Codec. In CBOR (not in *DAG-CBOR*) it's possible to have maps with integer keys:
+
+```
+A3               # map(3)
+   1A 00FF0000   # unsigned(16711680)
+   63            # text(3)
+      726564     # "red"
+   19 FF00       # unsigned(65280)
+   65            # text(5)
+      677265656E # "green"
+   18 FF         # unsigned(255)
+   64            # text(4)
+      626C7565   # "blue"
+```
+
+The same data with representation `listpairs`, which could be decoded into a valid Data Model (hence also *DAG-CBOR*), looks like this:
+
+
+```
+
+83                  # array(3)
+   82               # array(2)
+      1A 00FF0000   # unsigned(16711680)
+      63            # text(3)
+         726564     # "red"
+   82               # array(2)
+      19 FF00       # unsigned(65280)
+      65            # text(5)
+         677265656E # "green"
+   82               # array(2)
+      18 FF         # unsigned(255)
+      64            # text(4)
+         626C7565   # "blue"
+```
+
+You can see that the "pairs" add one level of indirection. So the changes are quite small.
+
+Though in case you want to get even closer to the native CBOR map with integers encoding, there could be a new representation be introduced, which stores the key value pairs in a flat list. So instead of…
+
+```json
+[[16711680, "red"], [65280, "green"], [255, "blue"]]
+```
+
+…the data would be represented as…
+
+```json
+[16711680, "red", 65280, "green", 255, "blue"]
+```
+
+…which would then encode in CBOR as:
+
+
+```
+86               # array(6)
+   1A 00FF0000   # unsigned(16711680)
+   63            # text(3)
+      726564     # "red"
+   19 FF00       # unsigned(65280)
+   65            # text(5)
+      677265656E # "green"
+   18 FF         # unsigned(255)
+   64            # text(4)
+      626C7565   # "blue"
+```
+
+The only difference to the map encoding is the first byte being `86` instead of `A3`, it doesn't have any other additional bytes.
+
+
+### Advanced uses
+
+Extending the `listpair` definition would also enable other advanced uses. Let's take DAG-CBOR as an example. The Codec specifies a certain ordering on the map keys, which is needed so that the same data is always encoded the same way. IPLD implementations might preserve the ordering of the codec and not define their own.
+
+If that's the case, then applications could decide to impose their own custom ordering, which would also be preserved in the Codec. You could even use it from strings keys. You would manually construct the list containing the pairs on the Data Model layer.
+
+
+Relation to the String discussion
+---------------------------------
+
+All this relates to the discussion whether Data Model Strings should be a sequence of 8-bit bytes or a sequence of Unicode characters. And related to that is the discussion whether `Map` keys [should be string, bytes or something else]. There it becomes clear that it would makes systems easier when `Map` keys could just be the same thing as string values and path segments.
+
+Though there is a problem. It is desirable that strings as values are Unicode-only to maximize interoperability, trading-off flexibility. Though for map keys, having the ability to use arbitrary bytes is nice in case you e.g. want to have filenames (which may contain non Unicode bytes) as keys. Having both things, "don't use arbitrary bytes in strings" and "it's OK to have bytes in strings" is a contradiction.
+
+With this proposal it's possible. Strings could be defined as sequence of Unicode character and disallow/discourage bytes. As a side-effect this would also enhance interoperability with Codecs that only support strings as key (e.g. Protocol Buffers) and programming languages alike.
+
+Though the use-case of filenames as map keys, e.g for IPFS, can still be served. You would use binary keys together with the `listpairs` representation to store the filenames.
+
+To me all this aligns well with:
+
+ > "Simple things should be simple, complex things should be possible."
+ > -- [Alan Kay]
+
+
+[@vmx]: https://github.com/vmx
+[@ianopolous]: https://github.com/ianopolous
+[IPLD Data Model]: https://specs.ipld.io/data-model-layer/data-model.html
+[IPLD Schemas]: https://specs.ipld.io/schemas/
+[`listpairs`]: https://specs.ipld.io/schemas/representations.html#map-listpairs-representation
+[should be string, bytes or something else]: https://hackmd.io/79okuu4eQoedhpmgVbZboA?view
+[Alan Kay]: https://www.quora.com/What-is-the-story-behind-Alan-Kay-s-adage-Simple-things-should-be-simple-complex-things-should-be-possible/answer/Alan-Kay-11


### PR DESCRIPTION
The IPLD Schema Map kind already supports a representation called `listpair`, which
could be extended to support advanced use cases like integer or bytes map keys.