### PR TITLE
Filecoin: initial pass at describing the block forms

### DIFF
--- a/data-structures/filecoin/chain.md
+++ b/data-structures/filecoin/chain.md
@@ -792,6 +792,14 @@ type DealOpsByEpochHAMTSetBucketEntry struct {
 
 <a name="minerv0state"></a>
 
+> Balance of Miner Actor should be greater than or equal to
+> the sum of PreCommitDeposits and LockedFunds.
+> It is possible for balance to fall below the sum of
+> PCD, LF and InitialPledgeRequirements, and this is a bad
+> state (IP Debt) that limits a miner actor's behavior (i.e. no balance withdrawals)
+> Excess balance as computed by st.GetAvailableBalance will be
+> withdrawable or usable for pre-commit deposit or pledge lock-up.
+
 ```ipldsch
 type MinerV0State struct {
   # Information not related to sectors
@@ -837,28 +845,45 @@ type MinerV0State struct {
 
 ```ipldsch
 type MinerV0Info struct {
-  Owner Address
-  Worker Address
+#Account that owns this miner.
+  # - Income and returned collateral are paid to this address.
+  # - This address is also allowed to change the worker address for the miner.
+  Owner Address # Must be an ID-address
+  # Worker account for this miner.
+  # The associated pubkey-type address is used to sign blocks and messages on behalf of this miner.
+  Worker Address # Must be an ID-address.
+  # Additional addresses that are permitted to submit messages controlling this actor (optional)
   ControlAddresses nullable [Address]
-  PendingWorkerKey nullable MinerV0WorkerChangeKey
+  PendingWorkerKey nullable MinerV0WorkerKeyChange
+  # Byte array representing a Libp2p identity that should be used when connecting to this miner
   PeerId PeerID
+  # Slice of byte arrays representing Libp2p multi-addresses used for establishing a connection with this miner
   Multiaddrs nullable [Multiaddr]
+  # The proof type used by this miner for sealing sectors
   SealProofType Int
+  # Amount of space in each sector committed by this miner.
+  # This is computed from the proof type and represented here redundantly.
   SectorSize SectorSize
+  # The number of sectors in each Window PoSt partition (proof).
+  # This is computed from the proof type and represented here redundantly.
   WindowPoStPartitionSectors Int
 } representation tuple
 
-type MinerV0WorkerChangeKey struct {
-  NewWorker Address
+type MinerV0WorkerKeyChange struct {
+  NewWorker Address # Must be an ID address
   EffectiveAt ChainEpoch
 } representation tuple
 ```
 
 ```ipldsch
+# VestingFunds represents the vesting table state for the miner.
+# It is a slice of (VestingEpoch, VestingAmount).
+# The slice will always be sorted by the VestingEpoch.
 type MinerV0VestingFunds struct {
   Funds [MinerV0VestingFund]
 } representation tuple
 
+# VestingFund represents miner funds that will vest at the given epoch.
 type MinerV0VestingFund struct {
   Epoch ChainEpoch
   Amount TokenAmount
@@ -866,6 +891,8 @@ type MinerV0VestingFund struct {
 ```
 
 ```ipldsch
+# Deadlines contains Deadline objects, describing the sectors due at the given
+# deadline and their state (faulty, terminated, recovering, etc.).
 type MinerV0Deadlines struct {
   Due MinerV0DeadlineLinkList
 } representation tuple
@@ -875,13 +902,28 @@ type MinerV0DeadlineLinkList [&MinerV0Deadline]
 ```
 
 ```ipldsch
+# Deadline holds the state for all sectors due at a specific deadline.
 type MinerV0Deadline struct {
+  # Partitions in this deadline, in order.
+  # The keys of this AMT are always sequential integers beginning with zero.
   Partitions &MinerV0PartitionAMT # AMT[PartitionNumber]Partition
+  # Maps epochs to partitions that _may_ have sectors that expire in or
+  # before that epoch, either on-time or early as faults.
+  # Keys are quantized to final epochs in each proving deadline.
+  # NOTE: Partitions MUST NOT be removed from this queue (until the
+  # associated epoch has passed) even if they no longer have sectors
+  # expiring at that epoch. Sectors expiring at this epoch may later be
+  # recovered, and this queue will not be updated at that time.
   ExpirationEpochs &BitFieldQueueAMT # AMT[ChainEpoch]BitField
+  # Partitions numbers with PoSt submissions since the proving period started.
   PostSubmissions BitField
+  # Partitions with sectors that terminated early.
   EarlyTerminations BitField
+  # The number of non-terminated sectors in this deadline (incl faulty).
   LiveSectors Int
+  # The total number of sectors in this deadline (incl dead).
   TotalSectors Int
+  # Memoized sum of faulty power in partitions.
   FaultyPower MinerV0PowerPair
 } representation tuple
 ```
@@ -913,7 +955,7 @@ type MinerV2State struct {
   # Information for all proven and not-yet-garbage-collected sectors.
   # Sectors are removed from this AMT when the partition to which the
   # sector belongs is compacted.
-  Sectors &MinerV0SectorOnChainInfoAMT # AMT[SectorNumber]SectorOnChainInfo
+  Sectors &MinerV2SectorOnChainInfoAMT # AMT[SectorNumber]SectorOnChainInfo
   # The first epoch in this miner's current proving period. This is the first epoch in which a PoSt for a
   # partition at the miner's first deadline may arrive. Alternatively, it is after the last epoch at which
   # a PoSt for the previous window is valid.
@@ -937,16 +979,33 @@ type MinerV2State struct {
 
 ```ipldsch
 type MinerV2Info struct {
-  Owner Address
-  Worker Address
-  ControlAddresses nullable [Address]
-  PendingWorkerKey nullable MinerV0WorkerChangeKey
+  # Account that owns this miner.
+  # - Income and returned collateral are paid to this address.
+  # - This address is also allowed to change the worker address for the miner.
+  Owner Address # Must be an ID-address
+  # Worker account for this miner.
+  # The associated pubkey-type address is used to sign blocks and messages on behalf of this miner.
+  Worker Address # Must be an ID-address
+  # Additional addresses that are permitted to submit messages controlling this actor (optional).
+  ControlAddresses nullable [Address] # Must all be ID addresses
+  PendingWorkerKey nullable MinerV0WorkerKeyChange
+  # Byte array representing a Libp2p identity that should be used when connecting to this miner.
   PeerId PeerID
+  # Slice of byte arrays representing Libp2p multi-addresses used for establishing a connection with this miner.
   Multiaddrs nullable [Multiaddr]
+  # The proof type used by this miner for sealing sectors.
   SealProofType Int
+  # Amount of space in each sector committed by this miner.
+  # This is computed from the proof type and represented here redundantly.
   SectorSize SectorSize
+  # The number of sectors in each Window PoSt partition (proof).
+  # This is computed from the proof type and represented here redundantly.
   WindowPoStPartitionSectors Int
+  # The next epoch this miner is eligible for certain permissioned actor methods
+  # and winning block elections as a result of being reported for a consensus fault.
   ConsensusFaultElapsed ChainEpoch
+  # A proposed new owner account for this miner.
+  # Must be confirmed by a message from the pending address itself.
   PendingOwnerAddress nullable Address
 } representation tuple
 ```
@@ -954,6 +1013,8 @@ type MinerV2Info struct {
 Ssame form as `MinerV0Deadlines` but the eventual link to `MinerV2Partition` is different.
 
 ```ipldsch
+# Deadlines contains Deadline objects, describing the sectors due at the given
+# deadline and their state (faulty, terminated, recovering, etc.).
 type MinerV2Deadlines struct {
   Due MinerV2DeadlineLinkList
 } representation tuple
@@ -963,13 +1024,28 @@ type MinerV2DeadlineLinkList [&MinerV2Deadline]
 ```
 
 ```ipldsch
+# Deadline holds the state for all sectors due at a specific deadline.
 type MinerV2Deadline struct {
+  # Partitions in this deadline, in order.
+  # The keys of this AMT are always sequential integers beginning with zero.
   Partitions &MinerV2PartitionAMT # AMT[PartitionNumber]Partition
+  # Maps epochs to partitions that _may_ have sectors that expire in or
+  # before that epoch, either on-time or early as faults.
+  # Keys are quantized to final epochs in each proving deadline.
+  # NOTE: Partitions MUST NOT be removed from this queue (until the
+  # associated epoch has passed) even if they no longer have sectors
+  # expiring at that epoch. Sectors expiring at this epoch may later be
+  # recovered, and this queue will not be updated at that time.
   ExpirationEpochs &BitFieldQueueAMT # AMT[ChainEpoch]BitField
+  # Partitions numbers with PoSt submissions since the proving period started.
   PostSubmissions BitField
+  # Partitions with sectors that terminated early.
   EarlyTerminations BitField
+  # The number of non-terminated sectors in this deadline (incl faulty).
   LiveSectors Int
+  # The total number of sectors in this deadline (incl dead).
   TotalSectors Int
+  # Memoized sum of faulty power in partitions.
   FaultyPower MinerV0PowerPair
 } representation tuple
 ```
@@ -996,22 +1072,29 @@ type MinerV0SectorPreCommitOnChainInfoHAMTBucketEntry struct {
   value MinerV0SectorPreCommitOnChainInfo # inline
 } representation tuple
 
+# Information stored on-chain for a pre-committed sector
 type MinerV0SectorPreCommitOnChainInfo struct {
   Info MinerV0SectorPreCommitInfo
   PreCommitDeposit TokenAmount
   PreCommitEpoch ChainEpoch
+  # Integral of active deals over sector lifetime
   DealWeight DealWeight
+  # Integral of active verified deals over sector lifetime
   VerifiedDealWeight DealWeight
 } representation tuple
 
+# Information provided by a miner when pre-committing a sector
 type MinerV0SectorPreCommitInfo struct {
   SealProof RegisteredSealProof
   SectorNumber SectorNumber
-  SealedCID &Any # A CID with fil-commitment-sealed + poseidon-bls12_381-ac-fc1
+  # CommR: A CID with fil-commitment-sealed + poseidon-bls12_381-ac-fc1
+  SealedCID &Any
   SealRandEpoch ChainEpoch
   DealIDs [DealID]
   Expiration ChainEpoch
+  # Whether to replace a "committed capacity" no-deal sector (requires non-empty DealIDs)
   ReplaceCapacity Bool
+  # The committed capacity sector to replace, and it's deadline/partition location
   ReplaceSectorDeadline Int
   ReplaceSectorPartition PartitionNumber
   ReplaceSectorNumber SectorNumber
@@ -1034,7 +1117,7 @@ type BitFieldQueueAMTNode struct {
 } representation tuple
 ```
 
-**AMT**: This is an ADL representing `type SectorOnChainInfoList [SectorOnChainInfo]` indexed by `SectorNumber`.
+**AMT**: This is an ADL representing `type V0SectorOnChainInfoList [V0SectorOnChainInfo]` indexed by `SectorNumber`.
 
 ```ipldsch
 type MinerV0SectorOnChainInfoAMT struct {
@@ -1049,19 +1132,71 @@ type MinerV0SectorOnChainInfoAMTNode struct {
   values [MinerV0SectorOnChainInfo]
 } representation tuple
 
+# Information stored on-chain for a proven sector
 type MinerV0SectorOnChainInfo struct {
   SectorNumber SectorNumber
+  # The seal proof type implies the PoSt proof/s
   SealProof RegisteredSealProof
-  SealedCID &Any # A CID with fil-commitment-sealed + poseidon-bls12_381-ac-fc1
+  # CommR: A CID with fil-commitment-sealed + poseidon-bls12_381-ac-fc1
+  SealedCID &Any
   DealIDs [DealID]
+  # Epoch during which the sector proof was accepted
   Activation ChainEpoch
+  # Epoch during which the sector expires
   Expiration ChainEpoch
+  # Integral of active deals over sector lifetime
   DealWeight DealWeight
+  # Integral of active verified deals over sector lifetime
   VerifiedDealWeight DealWeight
+  # Pledge collected to commit this sector
   InitialPledge TokenAmount
+  # Expected one day projection of reward for sector computed at activation time
   ExpectedDayReward TokenAmount
-  ExpectedStorageReward TokenAmount
+  # Expected twenty day projection of reward for sector computed at activation time
+  ExpectedStoragePledge TokenAmount
+} representation tuple
+```
+
+**AMT**: This is an ADL representing `type V2SectorOnChainInfoList [V2SectorOnChainInfo]` indexed by `SectorNumber`.
+
+```ipldsch
+type MinerV2SectorOnChainInfoAMT struct {
+  height Int
+  count Int
+  node MinerV2SectorOnChainInfoAMTNode
+} representation tuple
+
+type MinerV2SectorOnChainInfoAMTNode struct {
+  bitmap Bytes
+  children [&MinerV2SectorOnChainInfoAMTNode]
+  values [MinerV2SectorOnChainInfo]
+} representation tuple
+
+# Information stored on-chain for a proven sector
+type MinerV2SectorOnChainInfo struct {
+  SectorNumber SectorNumber
+  # The seal proof type implies the PoSt proof/s
+  SealProof RegisteredSealProof
+  # CommR: A CID with fil-commitment-sealed + poseidon-bls12_381-ac-fc1
+  SealedCID &Any
+  DealIDs [DealID]
+  # Epoch during which the sector proof was accepted
+  Activation ChainEpoch
+  # Epoch during which the sector expires
+  Expiration ChainEpoch
+  # Integral of active deals over sector lifetime
+  DealWeight DealWeight
+  # Integral of active verified deals over sector lifetime
+  VerifiedDealWeight DealWeight
+  # Pledge collected to commit this sector
+  InitialPledge TokenAmount
+  # Expected one day projection of reward for sector computed at activation time
+  ExpectedDayReward TokenAmount
+  # Expected twenty day projection of reward for sector computed at activation time
+  ExpectedStoragePledge TokenAmount
+  # Age of sector this sector replaced or zero
   ReplacedSectorAge ChainEpoch
+  # Day reward of sector this sector replace or zero
   ReplacedDayReward TokenAmount
 } representation tuple
 ```
@@ -1082,17 +1217,34 @@ type MinerV0PartitionAMTNode struct {
 } representation tuple
 
 type MinerV0Partition struct {
+  # Sector numbers in this partition, including faulty and terminated sectors
   Sectors BitField
+  # Subset of sectors detected/declared faulty and not yet recovered (excl. from PoSt).
+  # Faults ∩ Terminated = ∅
   Faults BitField
+  # Subset of faulty sectors expected to recover on next PoSt
+  # Recoveries ∩ Terminated = ∅
   Recoveries BitField
+  # Subset of sectors terminated but not yet removed from partition (excl. from PoSt)
   Terminated BitField
+  # Maps epochs sectors that expire in or before that epoch.
+  # An expiration may be an "on-time" scheduled expiration, or early "faulty" expiration.
+  # Keys are quantized to last-in-deadline epochs.
   ExpirationsEpochs &MinerV0ExpirationSetAMT # AMT[ChainEpoch]ExpirationSet
+  # Subset of terminated that were before their committed expiration epoch, by termination epoch.
+  # Termination fees have not yet been calculated or paid and associated deals have not yet been
+  # canceled but effective power has already been adjusted.
+  # Not quantized.
   EarlyTerminated &BitFieldQueueAMT # AMT[ChainEpoch]BitField
+  # Power of not-yet-terminated sectors (incl faulty)
   LivePower MinerV0PowerPair
+  # Power of currently-faulty sectors. FaultyPower <= LivePower.
   FaultyPower MinerV0PowerPair
+  # Power of expected-to-recover sectors. RecoveringPower <= FaultyPower.
   RecoveringPower MinerV0PowerPair
 } representation tuple
 
+# Value type for a pair of raw and QA power
 type MinerV0PowerPair struct {
   Raw StoragePower
   QA StoragePower
@@ -1115,16 +1267,37 @@ type MinerV2PartitionAMTNode struct {
 } representation tuple
 
 type MinerV2Partition struct {
+  # Sector numbers in this partition, including faulty, unproven, and terminated sectors
   Sectors BitField
+  # Unproven sectors in this partition. This bitfield will be cleared on
+  # a successful window post (or at the end of the partition's next
+  # deadline). At that time, any still unproven sectors will be added to
+  # the faulty sector bitfield.
   Unproven BitField
+  # Subset of sectors detected/declared faulty and not yet recovered (excl. from PoSt).
+  # Faults ∩ Terminated = ∅
   Faults BitField
+  # Subset of faulty sectors expected to recover on next PoSt
+  # Recoveries ∩ Terminated = ∅
   Recoveries BitField
+  # Subset of sectors terminated but not yet removed from partition (excl. from PoSt)
   Terminated BitField
+  # Maps epochs sectors that expire in or before that epoch.
+  # An expiration may be an "on-time" scheduled expiration, or early "faulty" expiration.
+  # Keys are quantized to last-in-deadline epochs.
   ExpirationsEpochs &MinerV0ExpirationSetAMT # AMT[ChainEpoch]ExpirationSet
+  # Subset of terminated that were before their committed expiration epoch, by termination epoch.
+  # Termination fees have not yet been calculated or paid and associated deals have not yet been
+  # canceled but effective power has already been adjusted.
+  # Not quantized.
   EarlyTerminated &BitFieldQueueAMT # AMT[ChainEpoch]BitField
+  # Power of not-yet-terminated sectors (incl faulty & unproven)
   LivePower MinerV0PowerPair
+  # Power of yet-to-be-proved sectors (never faulty)
   UnprovenPower MinerV0PowerPair
+  # Power of currently-faulty sectors. FaultyPower <= LivePower.
   FaultyPower MinerV0PowerPair
+  # Power of expected-to-recover sectors. RecoveringPower <= FaultyPower.
   RecoveringPower MinerV0PowerPair
 } representation tuple
 ```
@@ -1144,11 +1317,22 @@ type MinerV0ExpirationSetAMTNode struct {
   values [MinerV0ExpirationSet]
 } representation tuple
 
+# ExpirationSet is a collection of sector numbers that are expiring, either due to
+# expected "on-time" expiration at the end of their life, or unexpected "early" termination
+# due to being faulty for too long consecutively.
+# Note that there is not a direct correspondence between on-time sectors and active power;
+# a sector may be faulty but expiring on-time if it faults just prior to expected termination.
+# Early sectors are always faulty, and active power always represents on-time sectors.
 type MinerV0ExpirationSet struct {
+  # Sectors expiring "on time" at the end of their committed life
   OnTimeSectors BitField
+  # Sectors expiring "early" due to being faulty for too long
   EarlySectors BitField
+  # Pledge total for the on-time sectors
   OnTimePledge TokenAmount
+  # Power that is currently active (not faulty)
   ActivePower MinerV0PowerPair
+  # Power that is currently faulty
   FaultyPower MinerV0PowerPair
 } representation tuple
 ```
@@ -1163,9 +1347,14 @@ The MultisigActor state is the same in v0 and v2.
 
 ```ipldsch
 type MultisigV0State struct {
+   # Signers may be either public-key or actor ID-addresses. The ID address is canonical, but doesn't exist
+  # for a public key that has not yet received a message on chain.
+  # If any signer address is a public-key address, it will be resolved to an ID address and persisted
+  # in this state when the address is used.
   Signers [Address]
   NumApprovalsThreshold Int
   NextTxnID TransactionID
+  # Linear unlock
   InitialBalance TokenAmount
   StartEpoch ChainEpoch
   UnlockDuration ChainEpoch
@@ -1210,6 +1399,7 @@ type MultisigV0Transaction struct {
   Value TokenAmount
   Method MethodNum
   Params CborEncodedParams
+  # This address at index 0 is the transaction proposer, order of this slice must be preserved.
   Approved [Address]
 } representation tuple
 ```
@@ -1222,13 +1412,23 @@ The PaymentChannelActor state is the same in v0 and v2.
 
 <a name="paychv0state"></a>
 
+> A given payment channel actor is established by From
+> to enable off-chain microtransactions to To to be reconciled
+> and tallied on chain.
+
 ```ipldsch
 type PaychV0State struct {
+  # Channel owner, who has funded the actor
   From Address
+  # Recipient of payouts from channel
   To Address
+  # Amount successfully redeemed through the payment channel, paid out on `Collect()`
   ToSend BigInt
+  # Height at which the channel can be `Collected`
   SettlingAt ChainEpoch
+  # Height before which the channel `ToSend` cannot be collected
   MinSettleHeight ChainEpoch
+  # Collections of lane states for the channel, maintained in ID order.
   LaneStates &PaychV0LaneStatesAMT # AMT[Int]PaychV0LaneState
 } representation tuple
 ```
@@ -1258,6 +1458,8 @@ type PaychV0LaneStatesAMTNode struct {
   values [PaychV0LaneState]
 } representation tuple
 
+# The Lane state tracks the latest (highest) voucher nonce used to merge the lane
+# as well as the amount it has already redeemed.
 type PaychV0LaneState struct {
   Redeemed BigInt
   Nonce Int
@@ -1275,19 +1477,29 @@ The StoragePowerActor state is the same in v0 and v2.
 ```ipldsch
 type PowerV0State struct {
   TotalRawBytePower StoragePower
+  # TotalBytesCommitted includes claims from miners below min power threshold
   TotalBytesCommitted StoragePower
   TotalQualityAdjPower StoragePower
+  # TotalQABytesCommitted includes claims from miners below min power threshold
   TotalQABytesCommitted StoragePower
   TotalPledgeCollateral TokenAmount
+  # These fields are set once per epoch in the previous cron tick and used
+  # for consistent values across a single epoch's state transition.
   ThisEpochRawBytePower StoragePower
   ThisEpochQualityAdjPower StoragePower
   ThisEpochPledgeCollateral TokenAmount
   ThisEpochQAPowerSmoothed nullable V0FilterEstimate
   MinerCount Int
+  # Number of miners having proven the minimum consensus power
   MinerAboveMinPowerCount Int
+  # A queue of events to be triggered by cron, indexed by epoch
   CronEventQueue &PowerV0CronEventHAMT # Multimap: HAMT[ChainEpoch]AMT[PowerV0CronEvent]
+  # First epoch in which a cron task may be stored.
+  # Cron will iterate every epoch between this and the current epoch inclusively to find tasks to execute.
   FirstCronEpoch ChainEpoch
+  # Last epoch power cron tick has been processed
   LastProcessedCronEpoch ChainEpoch
+  # Claimed power for each miner
   Claims &PowerV0ClaimHAMT # HAMT[address]PowerV0Claim
   ProofValidationBatch nullable &ProofValidationBatchHAMT # Multimap: HAMT[Address]AMT[SealVerifyInfo]
 } representation tuple
@@ -1295,12 +1507,35 @@ type PowerV0State struct {
 
 #### v2
 
-_(Same as v0)_
-
 <a name="powerv2state"></a>
 
 ```ipldsch
-type PowerV2State PowerV0State
+type PowerV2State struct {
+  TotalRawBytePower StoragePower
+  # TotalBytesCommitted includes claims from miners below min power threshold
+  TotalBytesCommitted StoragePower
+  TotalQualityAdjPower StoragePower
+  # TotalQABytesCommitted includes claims from miners below min power threshold
+  TotalQABytesCommitted StoragePower
+  TotalPledgeCollateral TokenAmount
+  # These fields are set once per epoch in the previous cron tick and used
+  # for consistent values across a single epoch's state transition.
+  ThisEpochRawBytePower StoragePower
+  ThisEpochQualityAdjPower StoragePower
+  ThisEpochPledgeCollateral TokenAmount
+  ThisEpochQAPowerSmoothed V0FilterEstimate
+  MinerCount Int
+  # Number of miners having proven the minimum consensus power
+  MinerAboveMinPowerCount Int
+  # A queue of events to be triggered by cron, indexed by epoch
+  CronEventQueue &PowerV0CronEventHAMT # Multimap: HAMT[ChainEpoch]AMT[PowerV0CronEvent]
+  # First epoch in which a cron task may be stored.
+  # Cron will iterate every epoch between this and the current epoch inclusively to find tasks to execute.
+  FirstCronEpoch ChainEpoch
+  # Claimed power for each miner
+  Claims &PowerV2ClaimHAMT # HAMT[address]PowerV2Claim
+  ProofValidationBatch nullable &ProofValidationBatchHAMT # Multimap: HAMT[Address]AMT[SealVerifyInfo]
+} representation tuple
 ```
 
 **Multimap (HAMT+AMT)**: This is an ADL representing a List within a Map `type PowerV0CronEventMap {ChainEpochBytes:[PowerV0CronEvent]}`, where the `CronEvent` list is a queue.
@@ -1371,7 +1606,41 @@ type PowerV0ClaimMapHAMTBucketEntry struct {
 } representation tuple
 
 type PowerV0Claim struct {
+  # Sum of raw byte power for a miner's sectors
   RawBytePower StoragePower
+  # Sum of quality adjusted power for a miner's sectors
+  QualityAdjPower StoragePower
+} representation tuple
+```
+
+**HAMT**: This is an ADL representing `type PowerV2ClaimMap {Address:PowerV2Claim}`.
+
+```ipldsch
+type PowerV2ClaimMapHAMT struct {
+  map Bytes
+  data [ PowerV2ClaimMapHAMTElement ]
+} representation tuple
+
+type PowerV2ClaimMapHAMTElement union {
+  | PowerV2ClaimMapHAMTLink "0"
+  | PowerV2ClaimMapHAMTBucket "1"
+} representation keyed
+
+type PowerV2ClaimMapHAMTLink &PowerV2ClaimMapHAMT
+
+type PowerV2ClaimMapHAMTBucket [ PowerV2ClaimMapHAMTBucketEntry ]
+
+type PowerV2ClaimMapHAMTBucketEntry struct {
+  key Address
+  value PowerV2Claim
+} representation tuple
+
+type PowerV2Claim struct {
+  # Miner's proof type used to determine minimum miner size
+  SealProofType RegisteredSealProof
+  # Sum of raw byte power for a miner's sectors
+  RawBytePower StoragePower
+  # Sum of quality adjusted power for a miner's sectors
   QualityAdjPower StoragePower
 } representation tuple
 ```
@@ -1415,6 +1684,7 @@ type ProofValidationBatchAMTNode struct {
   values [SealVerifyInfo]
 } representation tuple
 
+# Information needed to verify a seal proof.
 type SealVerifyInfo struct {
   SealProof RegisteredSealProof
   SectorID SectorID
@@ -1422,6 +1692,7 @@ type SealVerifyInfo struct {
   Randomness Bytes
   InteractiveRandomness Bytes
   Proof Bytes
+  # Safe because we get those from the miner actor
   SealedCID &Any # CommR: A CID with fil-commitment-sealed + poseidon-bls12_381-ac-fc1
   UnsealedCID &Any # CommD: A CID with fil-commitment-unsealed + sha2_256-trunc254-padded
 } representation tuple
@@ -1437,8 +1708,13 @@ The VerifiedRegistryActor state is the same in v0 and v2.
 
 ```ipldsch
 type VerifregV0State struct {
+  # Root key holder multisig.
+  # Authorize and remove verifiers.
   RootKey Address
+  # Verifiers authorize VerifiedClients.
+  # Verifiers delegate their DataCap.
   Verifiers &DataCapHAMT
+  # VerifiedClients can add VerifiedClientData, up to DataCap.
   VerifiedClients &DataCapHAMT
 }
 ```

--- a/data-structures/filecoin/chain.md
+++ b/data-structures/filecoin/chain.md
@@ -1,5 +1,46 @@
 # Filecoin Main Chain Data Structures
 
+* [Basic Types](#basic-types)
+* [Crypto Types](#crypto-types)
+* [Genesis Block](#genesis-block)
+* [Chain](#chain)
+* [Messages](#messages)
+* [Actors](#actors)
+  * [Actor type linking](#actor-type-linking)
+  * [InitActor](#initactor)
+    * [v0](#v0)
+    * [v2](#v2)
+  * [CronActor](#cronactor)
+    * [v0](#v0-1)
+    * [v2](#v2-1)
+  * [RewardActor](#rewardactor)
+    * [v0](#v0-2)
+    * [v2](#v2-2)
+  * [AccountActor](#accountactor)
+    * [v0](#v0-3)
+    * [v2](#v2-3)
+  * [StorageMarketActor](#storagemarketactor)
+    * [v0](#v0-4)
+    * [v2](#v2-4)
+  * [StorageMinerActor](#storagemineractor)
+    * [v0](#v0-5)
+    * [v2](#v2-5)
+  * [MultisigActor](#multisigactor)
+    * [v0](#v0-6)
+    * [v2](#v2-6)
+  * [PaymentChannelActor](#paymentchannelactor)
+    * [v0](#v0-7)
+    * [v2](#v2-7)
+  * [StoragePowerActor](#storagepoweractor)
+    * [v0](#v0-8)
+    * [v2](#v2-8)
+  * [VerifiedRegistryActor](#verifiedregistryactor)
+    * [v0](#v0-9)
+    * [v2](#v2-9)
+  * [SystemActor](#systemactor)
+    * [v0](#v0-10)
+    * [v2](#v2-10)
+
 Schemas are grouped by their serialized blocks. Other than those types listed in "Basic Types" and "Crypto Types", each grouping of schema types in a code block represents a data structure that is serialized into a single IPLD block with its own Link (CID).
 
 Advanced Data Layouts (ADLs) are shown in their expanded form here, as the data appears on-block. Their logical forms for programmatic purposes are `Map` for the HAMT and `List` for the AMT.
@@ -288,6 +329,8 @@ type SignedMessageLinkAMTNode struct {
 
 **HAMT**: This is an ADL representing `type ActorsMap {Address:Actors}`.
 
+### Actor type linking
+
 Actors are identified by a Code which is represented as a CID. The current form
 uses a `raw` codec combined with an `identity` multihash to encode a set of
 fixed strings uniquely representing the Actor type. Version 0 Actors use the
@@ -298,30 +341,30 @@ The `code` field in the `Actor` struct contains this CID and indicates the type
 of block to be found when following the `head` link to load the specific Actor
 state.
 
-| Code string | CID | CID Bytes |
-| --- | --- | --- |
-| "fil/1/system" | `bafkqaddgnfwc6mjpon4xg5dfnu` | `0x0155000c66696c2f312f73797374656d` |
-| "fil/1/init" | `bafkqactgnfwc6mjpnfxgs5a` | `0x0155000a66696c2f312f696e6974` |
-| "fil/1/cron" | `bafkqactgnfwc6mjpmnzg63q` | `0x0155000a66696c2f312f63726f6e` |
-| "fil/1/storagepower" | `bafkqaetgnfwc6mjpon2g64tbm5sxa33xmvza` | `0x0155001266696c2f312f73746f72616765706f776572` |
-| "fil/1/storageminer" | `bafkqaetgnfwc6mjpon2g64tbm5sw22lomvza` | `0x0155001266696c2f312f73746f726167656d696e6572` |
-| "fil/1/storagemarket" | `bafkqae3gnfwc6mjpon2g64tbm5sw2ylsnnsxi` | `0x0155001366696c2f312f73746f726167656d61726b6574` |
-| "fil/1/paymentchannel" | `bafkqafdgnfwc6mjpobqxs3lfnz2gg2dbnzxgk3a` | `0x0155001466696c2f312f7061796d656e746368616e6e656c` |
-| "fil/1/reward" | `bafkqaddgnfwc6mjpojsxoylsmq` | `0x0155000c66696c2f312f726577617264` |
-| "fil/1/verifiedregistry" | `bafkqaftgnfwc6mjpozsxe2lgnfswi4tfm5uxg5dspe` | `0x0155001666696c2f312f76657269666965647265676973747279` |
-| "fil/1/account" | `bafkqadlgnfwc6mjpmfrwg33vnz2a` | `0x0155000d66696c2f312f6163636f756e74` |
-| "fil/1/multisig" | `bafkqadtgnfwc6mjpnv2wy5djonuwo` | `0x0155000e66696c2f312f6d756c7469736967` |
-| "fil/2/system" | `bafkqaddgnfwc6mrpon4xg5dfnu` | `0x0155000c66696c2f322f73797374656d` |
-| "fil/2/init" | `bafkqactgnfwc6mrpnfxgs5a` | `0x0155000a66696c2f322f696e6974` |
-| "fil/2/cron" | `bafkqactgnfwc6mrpmnzg63q` | `0x0155000a66696c2f322f63726f6e` |
-| "fil/2/storagepower" | `bafkqaetgnfwc6mrpon2g64tbm5sxa33xmvza` | `0x0155001266696c2f322f73746f72616765706f776572` |
-| "fil/2/storageminer" | `bafkqaetgnfwc6mrpon2g64tbm5sw22lomvza` | `0x0155001266696c2f322f73746f726167656d696e6572` |
-| "fil/2/storagemarket" | `bafkqae3gnfwc6mrpon2g64tbm5sw2ylsnnsxi` | `0x0155001366696c2f322f73746f726167656d61726b6574` |
-| "fil/2/paymentchannel" | `bafkqafdgnfwc6mrpobqxs3lfnz2gg2dbnzxgk3a` | `0x0155001466696c2f322f7061796d656e746368616e6e656c` |
-| "fil/2/reward" | `bafkqaddgnfwc6mrpojsxoylsmq` | `0x0155000c66696c2f322f726577617264` |
-| "fil/2/verifiedregistry" | `bafkqaftgnfwc6mrpozsxe2lgnfswi4tfm5uxg5dspe` | `0x0155001666696c2f322f76657269666965647265676973747279` |
-| "fil/2/account" | `bafkqadlgnfwc6mrpmfrwg33vnz2a` | `0x0155000d66696c2f322f6163636f756e74` |
-| "fil/2/multisig" | `bafkqadtgnfwc6mrpnv2wy5djonuwo` | `0x0155000e66696c2f322f6d756c7469736967` |
+| Code string | Actor state type | CID | CID Bytes |
+| --- | --- | --- | --- |
+| `"fil/1/init"` | [`InitV0State`](#initv0state) | `bafkqactgnfwc6mjpnfxgs5a` | `0x0155000a66696c2f312f696e6974` |
+| `"fil/2/init"` | [`InitV2State`](#initv2state) | `bafkqactgnfwc6mrpnfxgs5a` | `0x0155000a66696c2f322f696e6974` |
+| `"fil/1/cron"` | [`CronV0State`](#cronv0state) | `bafkqactgnfwc6mjpmnzg63q` | `0x0155000a66696c2f312f63726f6e` |
+| `"fil/2/cron"` | [`CronV2State`](#cronv2state) | `bafkqactgnfwc6mrpmnzg63q` | `0x0155000a66696c2f322f63726f6e` |
+| `"fil/1/reward"` | [`RewardV0State`](#rewardv0state) | `bafkqaddgnfwc6mjpojsxoylsmq` | `0x0155000c66696c2f312f726577617264` |
+| `"fil/2/reward"` | [`RewardV2State`](#rewardv2state) | `bafkqaddgnfwc6mrpojsxoylsmq` | `0x0155000c66696c2f322f726577617264` |
+| `"fil/1/account"` | [`AccountV0State`](#accountv0state) | `bafkqadlgnfwc6mjpmfrwg33vnz2a` | `0x0155000d66696c2f312f6163636f756e74` |
+| `"fil/2/account"` | [`AccountV2State`](#accountv2state) | `bafkqadlgnfwc6mrpmfrwg33vnz2a` | `0x0155000d66696c2f322f6163636f756e74` |
+| `"fil/1/storagemarket"` | [`MarketV0State`](#marketv0state) | `bafkqae3gnfwc6mjpon2g64tbm5sw2ylsnnsxi` | `0x0155001366696c2f312f73746f726167656d61726b6574` |
+| `"fil/2/storagemarket"` | [`MarketV2State`](#marketv2state) | `bafkqae3gnfwc6mrpon2g64tbm5sw2ylsnnsxi` | `0x0155001366696c2f322f73746f726167656d61726b6574` |
+| `"fil/1/storageminer"` | [`MinerV0State`](#minerv0state) | `bafkqaetgnfwc6mjpon2g64tbm5sw22lomvza` | `0x0155001266696c2f312f73746f726167656d696e6572` |
+| `"fil/2/storageminer"` | [`MinerV2State`](#minerv2state) | `bafkqaetgnfwc6mrpon2g64tbm5sw22lomvza` | `0x0155001266696c2f322f73746f726167656d696e6572` |
+| `"fil/1/multisig"` | [`MultisigV0State`](#multisigv0state) | `bafkqadtgnfwc6mjpnv2wy5djonuwo` | `0x0155000e66696c2f312f6d756c7469736967` |
+| `"fil/2/multisig"` | [`MultisigV2State`](#multisigv2state) | `bafkqadtgnfwc6mrpnv2wy5djonuwo` | `0x0155000e66696c2f322f6d756c7469736967` |
+| `"fil/1/paymentchannel"` | [`PaychV0State`](#paychv0state) | `bafkqafdgnfwc6mjpobqxs3lfnz2gg2dbnzxgk3a` | `0x0155001466696c2f312f7061796d656e746368616e6e656c` |
+| `"fil/2/paymentchannel"` | [`PaychV2State`](#paychv2state) | `bafkqafdgnfwc6mrpobqxs3lfnz2gg2dbnzxgk3a` | `0x0155001466696c2f322f7061796d656e746368616e6e656c` |
+| `"fil/1/storagepower"` | [`PowerV0State`](#powerv0state) | `bafkqaetgnfwc6mjpon2g64tbm5sxa33xmvza` | `0x0155001266696c2f312f73746f72616765706f776572` |
+| `"fil/2/storagepower"` | [`PowerV2State`](#powerv2state) | `bafkqaetgnfwc6mrpon2g64tbm5sxa33xmvza` | `0x0155001266696c2f322f73746f72616765706f776572` |
+| `"fil/1/verifiedregistry"` | [`VerifregV0State`](#verifregv0state) | `bafkqaftgnfwc6mjpozsxe2lgnfswi4tfm5uxg5dspe` | `0x0155001666696c2f312f76657269666965647265676973747279` |
+| `"fil/2/verifiedregistry"` | [`VerifregV2State`](#verifregv2state) | `bafkqaftgnfwc6mrpozsxe2lgnfswi4tfm5uxg5dspe` | `0x0155001666696c2f322f76657269666965647265676973747279` |
+| `"fil/1/system"` | [`SystemV0State`](#systemv0state) | `bafkqaddgnfwc6mjpon4xg5dfnu` | `0x0155000c66696c2f312f73797374656d` |
+| `"fil/2/system"` | [`SystemV2State`](#systemv2state) | `bafkqaddgnfwc6mrpon4xg5dfnu` | `0x0155000c66696c2f322f73797374656d` |
 
 ```ipldsch
 # An inline CID encoded as raw+identity, see above
@@ -362,7 +405,9 @@ type Actor struct {
 
 The InitActor state is the same in v0 and v2.
 
-**v0**
+#### v0
+
+<a name="initv0state"></a>
 
 ```ipldsch
 type InitV0State struct {
@@ -372,7 +417,11 @@ type InitV0State struct {
 } representation tuple
 ```
 
-**v2** _(Same as v0)_
+#### v2
+
+_(Same as v0)_
+
+<a name="initv2state"></a>
 
 ```ipldsch
 type InitV2State InitV0State
@@ -405,7 +454,9 @@ type ActorIDHAMTBucketEntry struct {
 
 The CronActor state is the same in v0 and v2.
 
-**v0**
+#### v0
+
+<a name="cronv0state"></a>
 
 ```ipldsch
 type CronV0State struct {
@@ -420,7 +471,11 @@ type CronV0Entry struct {
 } representation tuple
 ```
 
-**v2** _(Same as v0)_
+#### v2
+
+_(Same as v0)_
+
+<a name="cronv2state"></a>
 
 ```ipldsch
 type CronV2State CronV0State
@@ -430,7 +485,9 @@ type CronV2State CronV0State
 
 The RewardActor state differs between v0 and v2.
 
-**v0**
+#### v0
+
+<a name="rewardv0state"></a>
 
 ```ipldsch
 type RewardV0State struct {
@@ -468,7 +525,9 @@ type V0FilterEstimate struct {
 } representation tuple
 ```
 
-**v2**
+#### v2
+
+<a name="rewardv2state"></a>
 
 ```ipldsch
 type RewardV2State struct {
@@ -510,7 +569,9 @@ type RewardV2State struct {
 
 The CronActor state is the same in v0 and v2 and only contains an `Address`.
 
-**v0**
+#### v0
+
+<a name="accountv0state"></a>
 
 ```ipldsch
 type AccountV0State struct {
@@ -518,7 +579,11 @@ type AccountV0State struct {
 } representation tuple
 ```
 
-**v2** _(Same as v0)_
+#### v2
+
+_(Same as v0)_
+
+<a name="accountv2state"></a>
 
 ```ipldsch
 type AccountV2State AccountV0State
@@ -527,6 +592,10 @@ type AccountV2State AccountV0State
 ### StorageMarketActor
 
 The StorageMarketActor state is the same in v0 and v2.
+
+#### v0
+
+<a name="marketv0state"></a>
 
 ```ipldsch
 type MarketV0State struct {
@@ -554,7 +623,11 @@ type MarketV0State struct {
 } representation tuple
 ```
 
-**v2** _(Same as v0)_
+#### v2
+
+_(Same as v0)_
+
+<a name="marketv2state"></a>
 
 ```ipldsch
 type MarketV2State MarketV0State
@@ -715,7 +788,9 @@ type DealOpsByEpochHAMTSetBucketEntry struct {
 
 ### StorageMinerActor
 
-**v0**
+#### v0
+
+<a name="minerv0state"></a>
 
 ```ipldsch
 type MinerV0State struct {
@@ -811,7 +886,9 @@ type MinerV0Deadline struct {
 } representation tuple
 ```
 
-**v2**
+#### v2
+
+<a name="minerv2state"></a>
 
 ```ipldsch
 type MinerV2State struct {
@@ -1022,8 +1099,6 @@ type MinerV0PowerPair struct {
 } representation tuple
 ```
 
-**v2**
-
 **AMT**: This is an ADL representing `type MinerV2PartitionList [MinerV2Partition]` indexed by `PartitionNumber`.
 
 ```ipldsch
@@ -1082,7 +1157,9 @@ type MinerV0ExpirationSet struct {
 
 The MultisigActor state is the same in v0 and v2.
 
-**v0**
+#### v0
+
+<a name="multisigv0state"></a>
 
 ```ipldsch
 type MultisigV0State struct {
@@ -1096,7 +1173,11 @@ type MultisigV0State struct {
 } representation tuple
 ```
 
-**v2** _(Same as v0)_
+#### v2
+
+_(Same as v0)_
+
+<a name="multisigv2state"></a>
 
 ```ipldsch
 type MultisigV2State MultisigV0State
@@ -1137,7 +1218,9 @@ type MultisigV0Transaction struct {
 
 The PaymentChannelActor state is the same in v0 and v2.
 
-**v0**
+#### v0
+
+<a name="paychv0state"></a>
 
 ```ipldsch
 type PaychV0State struct {
@@ -1150,7 +1233,11 @@ type PaychV0State struct {
 } representation tuple
 ```
 
-**v2** _(Same as v0)_
+#### v2
+
+_(Same as v0)_
+
+<a name="paychv2state"></a>
 
 ```ipldsch
 type PaychV2State PaychV0State
@@ -1181,7 +1268,9 @@ type PaychV0LaneState struct {
 
 The StoragePowerActor state is the same in v0 and v2.
 
-**v0**
+#### v0
+
+<a name="powerv0state"></a>
 
 ```ipldsch
 type PowerV0State struct {
@@ -1204,7 +1293,11 @@ type PowerV0State struct {
 } representation tuple
 ```
 
-**v2** _(Same as v0)_
+#### v2
+
+_(Same as v0)_
+
+<a name="powerv2state"></a>
 
 ```ipldsch
 type PowerV2State PowerV0State
@@ -1338,7 +1431,9 @@ type SealVerifyInfo struct {
 
 The VerifiedRegistryActor state is the same in v0 and v2.
 
-**v0**
+#### v0
+
+<a name="verifregv0state"></a>
 
 ```ipldsch
 type VerifregV0State struct {
@@ -1348,7 +1443,11 @@ type VerifregV0State struct {
 }
 ```
 
-**v2** _(Same as v0)_
+#### v2
+
+_(Same as v0)_
+
+<a name="verifregv2state"></a>
 
 ```ipldsch
 type VerifregV2State VerifregV0State
@@ -1383,14 +1482,20 @@ Note that `SystemV0State` is an empty struct, which encodes as an empty CBOR arr
 
 The SystemActor state is the same in v0 and v2.
 
-**v0**
+#### v0
+
+<a name="systemv0state"></a>
 
 ```ipldsch
 type SystemV0State struct {
 } representation tuple
 ```
 
-**v2** _(Same as v0)_
+#### v2
+
+_(Same as v0)_
+
+<a name="systemv2state"></a>
 
 ```ipldsch
 type SystemV2State SystemV0State

--- a/data-structures/filecoin/chain.md
+++ b/data-structures/filecoin/chain.md
@@ -508,7 +508,7 @@ type RewardV0State struct {
   # This value is recomputed every non-null epoch and used in the next non-null epoch.
   ThisEpochReward TokenAmount
   # Smoothed ThisEpochReward
-  ThisEpochRewardSmoothed nullable V0FilterEstimate
+  ThisEpochRewardSmoothed nullable FilterEstimate
   # The baseline power the network is targeting at st.Epoch
   ThisEpochBaselinePower StoragePower
   # Epoch tracks for which epoch the Reward was computed
@@ -519,7 +519,7 @@ type RewardV0State struct {
 
 # Alpha Beta Filter "position" (value) and "velocity" (rate of change of value) estimates
 # Estimates are in Q.128 format
-type V0FilterEstimate struct {
+type FilterEstimate struct {
   PositionEstimate BigInt # Q.128
   VelocityEstimate BigInt # Q.128
 } representation tuple
@@ -548,7 +548,7 @@ type RewardV2State struct {
   # This value is recomputed every non-null epoch and used in the next non-null epoch.
   ThisEpochReward TokenAmount
   # Smoothed ThisEpochReward
-  ThisEpochRewardSmoothed V0FilterEstimate
+  ThisEpochRewardSmoothed FilterEstimate
   # The baseline power the network is targeting at st.Epoch
   ThisEpochBaselinePower StoragePower
   # Epoch tracks for which epoch the Reward was computed
@@ -845,7 +845,7 @@ type MinerV0State struct {
 
 ```ipldsch
 type MinerV0Info struct {
-#Account that owns this miner.
+  # Account that owns this miner.
   # - Income and returned collateral are paid to this address.
   # - This address is also allowed to change the worker address for the miner.
   Owner Address # Must be an ID-address
@@ -1488,7 +1488,7 @@ type PowerV0State struct {
   ThisEpochRawBytePower StoragePower
   ThisEpochQualityAdjPower StoragePower
   ThisEpochPledgeCollateral TokenAmount
-  ThisEpochQAPowerSmoothed nullable V0FilterEstimate
+  ThisEpochQAPowerSmoothed nullable FilterEstimate
   MinerCount Int
   # Number of miners having proven the minimum consensus power
   MinerAboveMinPowerCount Int
@@ -1523,7 +1523,7 @@ type PowerV2State struct {
   ThisEpochRawBytePower StoragePower
   ThisEpochQualityAdjPower StoragePower
   ThisEpochPledgeCollateral TokenAmount
-  ThisEpochQAPowerSmoothed V0FilterEstimate
+  ThisEpochQAPowerSmoothed FilterEstimate
   MinerCount Int
   # Number of miners having proven the minimum consensus power
   MinerAboveMinPowerCount Int

--- a/data-structures/filecoin/chain.md
+++ b/data-structures/filecoin/chain.md
@@ -63,8 +63,8 @@ type TransactionID # TxnID
 
 ```ipldsch
 type Signature union {
-  SignatureBLS 0
   SignatureSecp256k1 1
+  SignatureBLS 2
 } representation byteprefix
 ```
 

--- a/data-structures/filecoin/chain.md
+++ b/data-structures/filecoin/chain.md
@@ -96,6 +96,16 @@ type Signature union {
 
 ## Genesis Block
 
+There is a single block at the base of the entire chain with this layout. It is
+the only structure that uses an actual Map at the representation level (other
+structs use the `tuple` representation which encodes them as Lists). It is
+encoded with DAG-CBOR with a SHA2-256 which gives the CID:
+`bafyreiaqpwbbyjo4a42saasj36kkrpv4tsherf2e7bvezkert2a7dhonoi`.
+
+Note that this block does not conform to strict DAG-CBOR in that its Map keys
+are not sorted according to canonical rules. Therefore it does not round-trip
+cleanly through current DAG-CBOR codecs.
+
 ```ipldsch
 type Genesis struct {
   Datetime String
@@ -120,8 +130,10 @@ type TokenAmounts struct {
 # See Lotus chain/state/LoadStateTree()
 type StateRootLink &Any
 
-# The type hint here, `BlockHeader`, holds true except for the case of the
-# Genesis block, which is a different format entirely.
+# The type hint here, `BlockHeader`, holds true **except** for the case of the
+# final Genesis block, which is a different format entirely. Note there is a
+# `BlockHeader` "genesis" but its `Parents` is a single CID pointing to the
+# original genesis block which is described by the `Genesis` type.
 type TipSetKey [&BlockHeader]
 
 type BlockHeader struct {

--- a/data-structures/filecoin/chain.md
+++ b/data-structures/filecoin/chain.md
@@ -1,4 +1,4 @@
-# Filecoin Data Structures
+# Filecoin Main Chain Data Structures
 
 Schemas are grouped by their serialized blocks. Other than those types listed in "Basic Types" and "Crypto Types", each grouping of schema types in a code block represents a data structure that is serialized into a single IPLD block with its own Link (CID).
 
@@ -45,6 +45,8 @@ type PartitionNumber int
 type BitField bytes
 
 type StoragePower BigInt
+
+type DataCap StoragePower
 
 type DealID int
 
@@ -186,7 +188,7 @@ type Message struct {
   GasFeeCap BigInt
   GasPremium BigInt
   Method MethodNum
-  Params Bytes
+  Params Bytes # See the Filecoin Messages Data Structures document for encoded DAG-CBOR message params
 } representation tuple
 
 type SignedMessage struct {
@@ -540,7 +542,7 @@ type DealOpsByEpochHAMTSetBucketEntry struct {
 } representation tuple
 ```
 
-### StorageMarketActor
+### StorageMinerActor
 
 ```ipldsch
 type MinerV0State struct {
@@ -1209,7 +1211,7 @@ type DataCapHAMTBucket [ DataCapHAMTBucketEntry ]
 
 type DataCapHAMTBucketEntry struct {
   key Address # Address
-  value StoragePower # inline
+  value DataCap # inline
 } representation tuple
 ```
 

--- a/data-structures/filecoin/messages.md
+++ b/data-structures/filecoin/messages.md
@@ -1,74 +1,430 @@
 # Filecoin Messages Data Structures
 
-The following message parameters are encoded as DAG-CBOR and the resulting bytes placed in the `Params` field of the `Message` object.
+* [InitActor](#initactor)
+  * [v0](#v0)
+    * [Constructor](#constructor)
+    * [Exec](#exec)
+  * [v2](#v2)
+    * [Constructor](#constructor-1)
+    * [Exec](#exec-1)
+* [RewardActor](#rewardactor)
+  * [v0](#v0-1)
+    * [Constructor](#constructor-2)
+    * [AwardBlockReward](#awardblockreward)
+    * [ThisEpochReward](#thisepochreward)
+    * [UpdateNetworkKPI](#updatenetworkkpi)
+  * [v2](#v2-1)
+    * [Constructor](#constructor-3)
+    * [AwardBlockReward](#awardblockreward-1)
+    * [ThisEpochReward](#thisepochreward-1)
+    * [UpdateNetworkKPI](#updatenetworkkpi-1)
+* [CronActor](#cronactor)
+  * [v0](#v0-2)
+    * [Constructor](#constructor-4)
+    * [EpochTick](#epochtick)
+  * [v2](#v2-2)
+    * [Constructor](#constructor-5)
+    * [EpochTick](#epochtick-1)
+* [AccountActor](#accountactor)
+  * [v0](#v0-3)
+    * [Constructor](#constructor-6)
+    * [PubkeyAddress](#pubkeyaddress)
+  * [v2](#v2-3)
+    * [Constructor](#constructor-7)
+    * [PubkeyAddress](#pubkeyaddress-1)
+* [StorageMarketActor](#storagemarketactor)
+  * [v0](#v0-4)
+    * [Constructor](#constructor-8)
+    * [AddBalance](#addbalance)
+    * [WithdrawBalance](#withdrawbalance)
+    * [PublishStorageDeals](#publishstoragedeals)
+    * [VerifyDealsForActivation](#verifydealsforactivation)
+    * [ActivateDeals](#activatedeals)
+    * [OnMinerSectorsTerminate](#onminersectorsterminate)
+    * [ComputeDataCommitment](#computedatacommitment)
+    * [CronTick](#crontick)
+  * [v2](#v2-4)
+    * [Constructor](#constructor-9)
+    * [AddBalance](#addbalance-1)
+    * [WithdrawBalance](#withdrawbalance-1)
+    * [PublishStorageDeals](#publishstoragedeals-1)
+    * [VerifyDealsForActivation](#verifydealsforactivation-1)
+    * [ActivateDeals](#activatedeals-1)
+    * [OnMinerSectorsTerminate](#onminersectorsterminate-1)
+    * [ComputeDataCommitment](#computedatacommitment-1)
+    * [CronTick](#crontick-1)
+* [StorageMinerActor](#storagemineractor)
+  * [v0](#v0-5)
+    * [Constructor](#constructor-10)
+    * [ControlAddresses](#controladdresses)
+    * [ChangeWorkerAddress](#changeworkeraddress)
+    * [ChangePeerID](#changepeerid)
+    * [SubmitWindowedPoSt](#submitwindowedpost)
+    * [PreCommitSector](#precommitsector)
+    * [ProveCommitSector](#provecommitsector)
+    * [ExtendSectorExpiration](#extendsectorexpiration)
+    * [TerminateSectors](#terminatesectors)
+    * [DeclareFaults](#declarefaults)
+    * [DeclareFaultsRecovered](#declarefaultsrecovered)
+    * [OnDeferredCronEvent](#ondeferredcronevent)
+    * [CheckSectorProven](#checksectorproven)
+    * [AddLockedFund](#addlockedfund)
+    * [ReportConsensusFault](#reportconsensusfault)
+    * [WithdrawBalance](#withdrawbalance-2)
+    * [ConfirmSectorProofsValid](#confirmsectorproofsvalid)
+    * [ChangeMultiaddrs](#changemultiaddrs)
+    * [CompactPartitions](#compactpartitions)
+    * [CompactSectorNumbers](#compactsectornumbers)
+  * [v2](#v2-5)
+    * [Constructor](#constructor-11)
+    * [ControlAddresses](#controladdresses-1)
+    * [ChangeWorkerAddress](#changeworkeraddress-1)
+    * [ChangePeerID](#changepeerid-1)
+    * [SubmitWindowedPoSt](#submitwindowedpost-1)
+    * [PreCommitSector](#precommitsector-1)
+    * [ProveCommitSector](#provecommitsector-1)
+    * [ExtendSectorExpiration](#extendsectorexpiration-1)
+    * [TerminateSectors](#terminatesectors-1)
+    * [DeclareFaults](#declarefaults-1)
+    * [DeclareFaultsRecovered](#declarefaultsrecovered-1)
+    * [OnDeferredCronEvent](#ondeferredcronevent-1)
+    * [CheckSectorProven](#checksectorproven-1)
+    * [ApplyRewards](#applyrewards)
+    * [ReportConsensusFault](#reportconsensusfault-1)
+    * [WithdrawBalance](#withdrawbalance-3)
+    * [ConfirmSectorProofsValid](#confirmsectorproofsvalid-1)
+    * [ChangeMultiaddrs](#changemultiaddrs-1)
+    * [CompactPartitions](#compactpartitions-1)
+    * [CompactSectorNumbers](#compactsectornumbers-1)
+    * [ConfirmUpdateWorkerKey](#confirmupdateworkerkey)
+    * [RepayDebt](#repaydebt)
+    * [ChangeOwnerAddress](#changeowneraddress)
+* [MultisigActor](#multisigactor)
+  * [v0](#v0-6)
+    * [Constructor](#constructor-12)
+    * [Propose](#propose)
+    * [Approve](#approve)
+    * [Cancel](#cancel)
+    * [AddSigner](#addsigner)
+    * [RemoveSigner](#removesigner)
+    * [SwapSigner](#swapsigner)
+    * [ChangeNumApprovalsThreshold](#changenumapprovalsthreshold)
+    * [LockBalance](#lockbalance)
+  * [v2](#v2-6)
+    * [Constructor](#constructor-13)
+    * [Propose](#propose-1)
+    * [Approve](#approve-1)
+    * [Cancel](#cancel-1)
+    * [AddSigner](#addsigner-1)
+    * [RemoveSigner](#removesigner-1)
+    * [SwapSigner](#swapsigner-1)
+    * [ChangeNumApprovalsThreshold](#changenumapprovalsthreshold-1)
+    * [LockBalance](#lockbalance-1)
+* [PaymentChannelActor](#paymentchannelactor)
+  * [v0](#v0-7)
+    * [Constructor](#constructor-14)
+    * [UpdateChannelState](#updatechannelstate)
+    * [Settle](#settle)
+    * [Collect](#collect)
+  * [v2](#v2-7)
+    * [Constructor](#constructor-15)
+    * [UpdateChannelState](#updatechannelstate-1)
+    * [Settle](#settle-1)
+    * [Collect](#collect-1)
+* [StoragePowerActor](#storagepoweractor)
+  * [v0](#v0-8)
+    * [Constructor](#constructor-16)
+    * [CreateMiner](#createminer)
+    * [UpdateClaimedPower](#updateclaimedpower)
+    * [EnrollCronEvent](#enrollcronevent)
+    * [OnEpochTickEnd](#onepochtickend)
+    * [UpdatePledgeTotal](#updatepledgetotal)
+    * [OnConsensusFault](#onconsensusfault)
+    * [SubmitPoRepForBulkVerify](#submitporepforbulkverify)
+    * [CurrentTotalPower](#currenttotalpower)
+  * [v2](#v2-8)
+    * [Constructor](#constructor-17)
+    * [CreateMiner](#createminer-1)
+    * [UpdateClaimedPower](#updateclaimedpower-1)
+    * [EnrollCronEvent](#enrollcronevent-1)
+    * [OnEpochTickEnd](#onepochtickend-1)
+    * [UpdatePledgeTotal](#updatepledgetotal-1)
+    * [OnConsensusFault](#onconsensusfault-1)
+    * [SubmitPoRepForBulkVerify](#submitporepforbulkverify-1)
+    * [CurrentTotalPower](#currenttotalpower-1)
+* [VerifiedRegistryActor](#verifiedregistryactor)
+  * [v0](#v0-9)
+    * [Constructor](#constructor-18)
+    * [AddVerifier](#addverifier)
+    * [RemoveVerifier](#removeverifier)
+    * [AddVerifiedClient](#addverifiedclient)
+    * [UseBytes](#usebytes)
+    * [RestoreBytes](#restorebytes)
+  * [v2](#v2-9)
+    * [Constructor](#constructor-19)
+    * [AddVerifier](#addverifier-1)
+    * [RemoveVerifier](#removeverifier-1)
+    * [AddVerifiedClient](#addverifiedclient-1)
+    * [UseBytes](#usebytes-1)
+    * [RestoreBytes](#restorebytes-1)
+* [SystemActor](#systemactor)
+  * [v0](#v0-10)
+    * [Constructor](#constructor-20)
+  * [v2](#v2-10)
+    * [Constructor](#constructor-21)
 
-Each message parameters type is named `MessageParamsActorTypeMessageType`, where `ActorType` is the name of the actor and `MessageType` is the type of message being sent..
+Each actor accepts a number of messages. Each message requires a DAG-CBOR encoded parameters structure and a DAG-CBOR encoded return value.
+
+Below, the message type parameters are named in the following way: `MessageParamsACTORVXTYPE` where `ACTOR` is the actor name, `X` is the version (`0` or `2`) and `TYPE` is the message type. Likewise, the returns are named `MessageReturnACTORVXTYPE`.
+
+Most parameters and returns are identical between v0 and v2. The types are present for v2 in all cases but are aliased to the v0 type where the details haven't changed.
 
 ## InitActor
 
+### v0
+
+#### Constructor
+
 ```ipldsch
-type MessageParamsInitConstructor struct {
+type MessageParamsInitV0Constructor struct {
   NetworkName String
 } representation tuple
 
-type MessageParamsInitExec struct {
+type MessageReturnInitV0Constructor struct {
+} representation tuple
+```
+
+#### Exec
+
+```ipldsch
+type MessageParamsInitV0Exec struct {
   CodeCID &Any # An inline CID encoded as raw+identity
   ConstructorParams Bytes
 } representation tuple
+
+type MessageReturnInitV0Exec struct {
+  IDAddress Address # The canonical ID-based address for the actor
+  RobustAddress Address # A more expensive but re-org-safe address for the newly created actor
+} representation tuple
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsInitV2Constructor MessageParamsInitV0Constructor
+type MessageReturnInitV2Constructor MessageReturnInitV0Constructor
+```
+
+#### Exec
+
+```ipldsch
+type MessageParamsInitV2Exec MessageParamsInitV0Exec
+type MessageReturnInitV2Exec MessageReturnInitV0Exec
 ```
 
 ## RewardActor
 
+### v0
+
+#### Constructor
+
 ```ipldsch
-type MessageParamsRewardConstructor StoragePower
+type MessageParamsRewardV0Constructor StoragePower
 
-type MessageParamsRewardAwardBlockReward struct {
+type MessageReturnRewardV0Constructor struct {
+} representation tuple
+```
+
+#### AwardBlockReward
+
+```ipldsch
+type MessageParamsRewardV0AwardBlockReward struct {
   Miner Address
-  Penalty TokenAmount
-  GasReward TokenAmount
-  WinCount Int
+  Penalty TokenAmount # penalty for including bad messages in a block, >= 0
+  GasReward TokenAmount # gas reward from all gas fees in a block, >= 0
+  WinCount Int # number of reward units won, > 0
 } representation tuple
 
-type MessageParamsRewardThisEpochReward struct {
+type MessageReturnRewardV0Constructor struct {
+} representation tuple
+```
+
+#### ThisEpochReward
+
+```ipldsch
+type MessageParamsRewardV0ThisEpochReward struct {
 } representation tuple
 
-type MessageParamsRewardUpdateNetworkKPI StoragePower
+type MessageReturnRewardV0ThisEpochReward struct {
+  ThisEpochReward TokenAmount
+  ThisEpochRewardSmoothed FilterEstimate
+  ThisEpochBaselinePower StoragePower
+} representation tuple
+```
+
+#### UpdateNetworkKPI
+
+```ipldsch
+type MessageParamsRewardV0UpdateNetworkKPI StoragePower
+
+type MessageReturnRewardV0UpdateNetworkKPI struct {
+} representation tuple
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsRewardV2Constructor MessageParamsRewardV0Constructor
+type MessageReturnRewardV2Constructor MessageReturnRewardV0Constructor
+```
+
+#### AwardBlockReward
+
+```ipldsch
+type MessageParamsRewardV2AwardBlockReward MessageParamsRewardV0AwardBlockReward
+type MessageReturnRewardV2Constructor MessageReturnRewardV0Constructor
+```
+
+#### ThisEpochReward
+
+```ipldsch
+type MessageParamsRewardV2ThisEpochReward MessageParamsRewardV0ThisEpochReward
+
+type MessageReturnRewardV2ThisEpochReward struct {
+  ThisEpochRewardSmoothed FilterEstimate
+  ThisEpochBaselinePower StoragePower
+} representation tuple
+```
+
+#### UpdateNetworkKPI
+
+```ipldsch
+type MessageParamsRewardV2UpdateNetworkKPI MessageParamsRewardV0UpdateNetworkKPI
+type MessageReturnRewardV2UpdateNetworkKPI MessageReturnRewardV0UpdateNetworkKPI
 ```
 
 ## CronActor
 
+### v0
+
+#### Constructor
+
 ```ipldsch
-type MessageParamsCronConstructor struct {
+type MessageParamsCronV0Constructor struct {
   Entries [CronV0Entry]
 } representation tuple
 
-type MessageParamsCronEpochTick struct {
+type MessageReturnCronV0Constructor struct {
 } representation tuple
+```
+
+#### EpochTick
+
+```ipldsch
+type MessageParamsCronV0EpochTick struct {
+} representation tuple
+
+type MessageReturnCronV0EpochTick struct {
+} representation tuple
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsCronV2Constructor MessageParamsCronV0Constructor
+type MessageReturnCronV2Constructor MessageReturnCronV0Constructor
+```
+
+#### EpochTick
+
+```ipldsch
+type MessageParamsCronV2EpochTick MessageParamsCronV0EpochTick
+type MessageReturnCronV2EpochTick MessageReturnCronV0EpochTick
 ```
 
 ## AccountActor
 
-```ipldsch
-type MessageParamsAccountConstructor Address
+### v0
 
-type MessageParamsAccountPubkeyAddress struct {
+#### Constructor
+
+```ipldsch
+type MessageParamsAccountV0Constructor Address
+
+type MessageReturnAccountV0Constructor struct {
 } representation tuple
+```
+
+#### PubkeyAddress
+
+```ipldsch
+type MessageParamsAccountV0PubkeyAddress struct {
+} representation tuple
+
+type MessageReturnAccountV0PubkeyAddress Address
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsAccountV2Constructor MessageParamsAccountV0Constructor
+type MessageReturnAccountV2Constructor MessageReturnAccountV0Constructor
+```
+
+#### PubkeyAddress
+
+```ipldsch
+type MessageParamsAccountV2PubkeyAddress MessageParamsAccountV0PubkeyAddress
+type MessageReturnAccountV2PubkeyAddress MessageReturnAccountV0PubkeyAddress
 ```
 
 ## StorageMarketActor
 
+### v0
+
+#### Constructor
+
 ```ipldsch
-type MessageParamsMarketConstructor struct {
+type MessageParamsMarketV0Constructor struct {
 } representation tuple
 
-type MessageParamsMarketAddBalance Address
+type MessageReturnMarketV0Constructor struct {
+} representation tuple
+```
 
-type MessageParamsMarketWithdrawBalance struct {
+#### AddBalance
+
+```ipldsch
+type MessageParamsMarketV0AddBalance Address
+
+type MessageReturnMarketV0AddBalance struct {
+} representation tuple
+```
+
+#### WithdrawBalance
+
+```ipldsch
+type MessageParamsMarketV0WithdrawBalance struct {
   ProviderOrClientAmount Address
   Amount TokenAmount
 } representation tuple
 
-type MessageParamsMarketPublishStorageDeals struct {
+type MessageReturnMarketV0WithdrawBalance struct {
+} representation tuple
+```
+
+#### PublishStorageDeals
+
+```ipldsch
+type MessageParamsMarketV0PublishStorageDeals struct {
   Deals [MarketClientDealProposal]
 } representation tuple
 
@@ -77,35 +433,150 @@ type MarketClientDealProposal struct {
   ClientSignature Signature
 } representation tuple
 
-type MessageParamsMarketVerifyDealsForActivation struct {
+type MessageReturnMarketV0PublishStorageDeals struct {
+  IDs [DealID]
+} representation tuple
+```
+
+#### VerifyDealsForActivation
+
+```ipldsch
+type MessageParamsMarketV0VerifyDealsForActivation struct {
   DealIDs [DealID]
   SectorExpiry ChainEpoch
   SectorStart ChainEpoch
 } representation tuple
 
-type MessageParamsMarketActivateDeals struct {
+type MessageReturnMarketV0VerifyDealsForActivation struct {
+  DealWeight DealWeight
+  VerifiedDealWeight DealWeight
+} representation tuple
+```
+
+#### ActivateDeals
+
+```ipldsch
+type MessageParamsMarketV0ActivateDeals struct {
   DealIDs [DealID]
   SectorExpiry ChainEpoch
 } representation tuple
 
-type MessageParamsMarketOnMinerSectorsTerminate struct {
+type MessageReturnMarketV0ActivateDeals struct {
+} representation tuple
+```
+
+#### OnMinerSectorsTerminate
+
+```ipldsch
+type MessageParamsMarketV0OnMinerSectorsTerminate struct {
   Epoch ChainEpoch
   DealIDs [DealID]
 } representation tuple
 
-type MessageParamsMarketComputeDataCommitment struct {
+type MessageReturnMarketV0OnMinerSectorsTerminate struct {
+} representation tuple
+```
+
+#### ComputeDataCommitment
+
+```ipldsch
+type MessageParamsMarketV0ComputeDataCommitment struct {
   DealIDs [DealID]
   SectorType RegisteredSealProof
 } representation tuple
 
-type MessageParamsMarketCronTick struct {
+# CommD: A CID with fil-commitment-unsealed + sha2_256-trunc254-padded
+type MessageReturnMarketV0ComputeDataCommitment &Any
+```
+
+#### CronTick
+
+```ipldsch
+type MessageParamsMarketV0CronTick struct {
 } representation tuple
+
+type MessageReturnMarketV0CronTick struct {
+} representation tuple
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsMarketV2Constructor MessageParamsMarketV0Constructor
+type MessageReturnMarketV2Constructor MessageReturnMarketV0Constructor
+```
+
+#### AddBalance
+
+```ipldsch
+type MessageParamsMarketV2AddBalance MessageParamsMarketV0AddBalance
+type MessageReturnMarketV2AddBalance MessageReturnMarketV0AddBalance
+```
+
+#### WithdrawBalance
+
+```ipldsch
+type MessageParamsMarketV2WithdrawBalance MessageParamsMarketV0WithdrawBalance
+type MessageReturnMarketV2WithdrawBalance MessageReturnMarketV0WithdrawBalance
+```
+
+#### PublishStorageDeals
+
+```ipldsch
+type MessageParamsMarketV2PublishStorageDeals MessageParamsMarketV0PublishStorageDeals
+type MessageReturnMarketV2PublishStorageDeals MessageReturnMarketV0PublishStorageDeals
+```
+
+#### VerifyDealsForActivation
+
+```ipldsch
+type MessageParamsMarketV2VerifyDealsForActivation MessageParamsMarketV0VerifyDealsForActivation
+
+type MessageReturnMarketV2VerifyDealsForActivation struct {
+  DealWeight DealWeight
+  VerifiedDealWeight DealWeight
+  DealSpace Int
+} representation tuple
+```
+
+#### ActivateDeals
+
+```ipldsch
+type MessageParamsMarketV2ActivateDeals MessageParamsMarketV0ActivateDeals
+type MessageReturnMarketV2ActivateDeals MessageReturnMarketV0ActivateDeals
+```
+
+#### OnMinerSectorsTerminate
+
+```ipldsch
+type MessageParamsMarketV2OnMinerSectorsTerminate MessageParamsMarketV0OnMinerSectorsTerminate
+type MessageReturnMarketV2OnMinerSectorsTerminate MessageReturnMarketV0OnMinerSectorsTerminate
+```
+
+#### ComputeDataCommitment
+
+```ipldsch
+type MessageParamsMarketV2ComputeDataCommitment MessageParamsMarketV0ComputeDataCommitment
+type MessageReturnMarketV2ComputeDataCommitment MessageReturnMarketV0ComputeDataCommitment
+```
+
+#### CronTick
+
+```ipldsch
+type MessageParamsMarketV2CronTick MessageParamsMarketV0CronTick
+type MessageReturnMarketV2CronTick MessageReturnMarketV0CronTick
 ```
 
 ## StorageMinerActor
 
+### v0
+
+#### Constructor
+
 ```ipldsch
-type MessageParamsMinerConstructor struct {
+type MessageParamsMinerV0Constructor struct {
   OwnerAddr Address
   WorkerAddr Address
   ControlAddrs [Address]
@@ -114,25 +585,61 @@ type MessageParamsMinerConstructor struct {
   Multiaddrs [Multiaddrs]
 } representation tuple
 
-type MessageParamsMinerControlAddresses struct {
+type MessageReturnMinerV0Constructor struct {
+} representation tuple
+```
+
+#### ControlAddresses
+
+```ipldsch
+type MessageParamsMinerV0ControlAddresses struct {
+} representation tuple
+
+type MessageReturnMinerV0ControlAddresses struct {
+  Owner Address
+  Worker Address
+  ControlAddrs [Address]
+} representation tuple
+```
+
+#### ChangeWorkerAddress
+
+```ipldsch
+type MessageParamsMinerV0ChangeWorkerAddress struct {
   NewWorker Address
   NewControlAddrs [Address]
 } representation tuple
 
-type MessageParamsMinerChangeWorkerAddress struct {
-  NewWorker Address
-  NewControlAddrs [Address]
+type MessageReturnMinerV0ChangeWorkerAddress struct {
 } representation tuple
+```
 
-type MessageParamsMinerChangePeerID struct {
+#### ChangePeerID
+
+```ipldsch
+type MessageParamsMinerV0ChangePeerID struct {
   NewID PeerID
 } representation tuple
 
-type MessageParamsMinerSubmitWindowedPoSt struct {
+type MessageReturnMinerV0ChangePeerID struct {
+} representation tuple
+```
+
+#### SubmitWindowedPoSt
+
+```ipldsch
+# Information submitted by a miner to provide a Window PoSt.
+type MessageParamsMinerV0SubmitWindowedPoSt struct {
+  # The deadline index which the submission targets
   Deadline Int
+  # The partitions being proven
   Partitions [MinerPostPartition]
+  # Array of proofs, one per distinct registered proof type present in the sectors being proven.
+  # In the usual case of a single proof type, this array will always have a single element (independent of number of partitions).
   Proofs [PoStProof]
+  # The epoch at which these proofs is being committed to a particular chain
   ChainCommitEpoch ChainEpoch
+  # The ticket randomness on the chain at the ChainCommitEpoch on the chain this post is committed to
   ChainCommitRand Bytes
 } representation tuple
 
@@ -148,14 +655,35 @@ type PoStProof struct {
 
 type RegisteredPoStProof int
 
-type MessageParamsMinerPreCommitSector MinerV0SectorPreCommitInfo
+type MessageReturnMinerV0SubmitWindowedPoSt struct {
+} representation tuple
+```
 
-type MessageParamsMinerProveCommitSector struct {
+#### PreCommitSector
+
+```ipldsch
+type MessageParamsMinerV0PreCommitSector MinerV0SectorPreCommitInfo
+
+type MessageReturnMinerV0PreCommitSector struct {
+} representation tuple
+```
+
+#### ProveCommitSector
+
+```ipldsch
+type MessageParamsMinerV0ProveCommitSector struct {
   SectorNumber SectorNumber
   Proof Bytes
 } representation tuple
 
-type MessageParamsMinerExtendSectorExpiration struct {
+type MessageReturnMinerV0ProveCommitSector struct {
+} representation tuple
+```
+
+#### ExtendSectorExpiration
+
+```ipldsch
+type MessageParamsMinerV0ExtendSectorExpiration struct {
   Extension [MinerExpirationExtend]
 } representation tuple
 
@@ -166,7 +694,14 @@ type MinerExpirationExtend struct {
   NewExpiration ChainEpoch
 } representation tuple
 
-type MessageParamsMinerTerminateSectors struct {
+type MessageReturnMinerV0ExtendSectorExpiration struct {
+} representation tuple
+```
+
+#### TerminateSectors
+
+```ipldsch
+type MessageParamsMinerV0TerminateSectors struct {
   Terminations [MinerTerminationDeclaration]
 } representation tuple
 
@@ -176,7 +711,20 @@ type MinerTerminationDeclaration struct {
   Sectors BitField
 } representation tuple
 
-type MessageParamsMinerDeclareFaults struct {
+type MessageReturnMinerV0TerminateSectors struct {
+  # Set to true if all early termination work has been completed. When
+  # false, the miner may choose to repeatedly invoke TerminateSectors
+  # with no new sectors to process the remainder of the pending
+  # terminations. While pending terminations are outstanding, the miner
+  # will not be able to withdraw funds.
+  Done Bool
+} representation tuple
+```
+
+#### DeclareFaults
+
+```ipldsch
+type MessageParamsMinerV0DeclareFaults struct {
   Faults [MinerFaultDeclaration]
 } representation tuple
 
@@ -186,7 +734,14 @@ type MinerFaultDeclaration struct {
   Sectors BitField
 } representation tuple
 
-type MessageParamsMinerDeclareFaultsRecovered struct {
+type MessageReturnMinerV0DeclareFaults struct {
+} representation tuple
+```
+
+#### DeclareFaultsRecovered
+
+```ipldsch
+type MessageParamsMinerV0DeclareFaultsRecovered struct {
   Recoveries [MinerRecoveryDeclaration]
 } representation tuple
 
@@ -196,138 +751,548 @@ type MinerRecoveryDeclaration struct {
   Sectors BitField
 } representation tuple
 
-type MessageParamsMinerOnDeferredCronEvent struct {
+type MessageReturnMinerV0DeclareFaultsRecovered struct {
+} representation tuple
+```
+
+#### OnDeferredCronEvent
+
+```ipldsch
+type MessageParamsMinerV0OnDeferredCronEvent struct {
   EventType CronEventType
 } representation tuple
 
 type CronEventType int
 
-type MessageParamsMinerCheckSectorProven struct {
+type MessageReturnMinerV0OnDeferredCronEvent struct {
+} representation tuple
+```
+
+#### CheckSectorProven
+
+```ipldsch
+type MessageParamsMinerV0CheckSectorProven struct {
   SectorNumber SectorNumber
 } representation tuple
 
+type MessageReturnMinerV0CheckSectorProven struct {
+} representation tuple
+```
+
+#### AddLockedFund
+
+```ipldsch
 type MessageParamsMinerV0AddLockedFund TokenAmount
 
-type MessageParamsMinerV2ApplyRewards struct {
-  Reward TokenAmount
-  Penalty TokenAmount
+type MessageReturnMinerV0AddLockedFund struct {
 } representation tuple
+```
 
-type MessageParamsMinerReportConsensusFault struct {
+#### ReportConsensusFault
+
+```ipldsch
+type MessageParamsMinerV0ReportConsensusFault struct {
   BlockHeader1 Bytes
   BlockHeader2 Bytes
   BlockHeaderExtra Bytes
 } representation tuple
 
-type MessageParamsMinerWithdrawBalance struct {
+type MessageReturnMinerV0ReportConsensusFault struct {
+} representation tuple
+```
+
+#### WithdrawBalance
+
+```ipldsch
+type MessageParamsMinerV0WithdrawBalance struct {
   AmountRequested TokenAmount
 } representation tuple
 
-type MessageParamsMinerConfirmSectorProofsValid struct {
+type MessageReturnMinerV0WithdrawBalance struct {
+} representation tuple
+```
+
+#### ConfirmSectorProofsValid
+
+```ipldsch
+type MessageParamsMinerV0ConfirmSectorProofsValid struct {
   Sectors [SectorNumber]
 } representation tuple
 
-type MessageParamsMinerChangeMultiaddrs struct {
+type MessageReturnMinerV0ConfirmSectorProofsValid struct {
+} representation tuple
+```
+
+#### ChangeMultiaddrs
+
+```ipldsch
+type MessageParamsMinerV0ChangeMultiaddrs struct {
   NewMultiaddrs [Multiaddrs]
 } representation tuple
 
-type MessageParamsMinerCompactPartitions struct {
+type MessageReturnMinerV0ChangeMultiaddrs struct {
+} representation tuple
+```
+
+#### CompactPartitions
+
+```ipldsch
+type MessageParamsMinerV0CompactPartitions struct {
   Deadline Int
   Partitions BitField
 } representation tuple
 
-type MessageParamsMinerCompactSectorNumbers struct {
+type MessageReturnMinerV0CompactPartitions struct {
+} representation tuple
+```
+
+#### CompactSectorNumbers
+
+```ipldsch
+type MessageParamsMinerV0CompactSectorNumbers struct {
   MaskSectorNumbers BitField
 } representation tuple
 
+type MessageReturnMinerV0CompactSectorNumbers struct {
+} representation tuple
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsMinerV2Constructor MessageParamsMinerV0Constructor
+type MessageReturnMinerV2Constructor MessageReturnMinerV0Constructor
+```
+
+#### ControlAddresses
+
+```ipldsch
+type MessageParamsMinerV2ControlAddresses MessageParamsMinerV0ControlAddresses
+
+type MessageReturnMinerV2ControlAddresses struct {
+  Owner Address
+  Worker Address
+  ControlAddrs [Address]
+} representation tuple
+
+```
+
+#### ChangeWorkerAddress
+
+```ipldsch
+type MessageParamsMinerV2ChangeWorkerAddress MessageParamsMinerV0ChangeWorkerAddress
+type MessageReturnMinerV2ChangeWorkerAddress MessageReturnMinerV0ChangeWorkerAddress
+```
+
+#### ChangePeerID
+
+```ipldsch
+type MessageParamsMinerV2ChangePeerID MessageParamsMinerV0ChangePeerID
+type MessageReturnMinerV2ChangePeerID MessageReturnMinerV0ChangePeerID
+```
+
+#### SubmitWindowedPoSt
+
+```ipldsch
+type MessageParamsMinerV2SubmitWindowedPoSt MessageParamsMinerV0SubmitWindowedPoSt
+type MessageReturnMinerV2SubmitWindowedPoSt MessageReturnMinerV0SubmitWindowedPoSt
+```
+
+#### PreCommitSector
+
+```ipldsch
+type MessageParamsMinerV2PreCommitSector MessageParamsMinerV0PreCommitSector
+type MessageReturnMinerV2PreCommitSector MessageReturnMinerV0PreCommitSector
+```
+
+#### ProveCommitSector
+
+```ipldsch
+type MessageParamsMinerV2ProveCommitSector MessageParamsMinerV0ProveCommitSector
+type MessageReturnMinerV2ProveCommitSector MessageReturnMinerV0ProveCommitSector
+```
+
+#### ExtendSectorExpiration
+
+```ipldsch
+type MessageParamsMinerV2ExtendSectorExpiration MessageParamsMinerV0ExtendSectorExpiration
+type MessageReturnMinerV2ExtendSectorExpiration MessageReturnMinerV0ExtendSectorExpiration
+```
+
+#### TerminateSectors
+
+```ipldsch
+type MessageParamsMinerV2TerminateSectors MessageParamsMinerV0TerminateSectors
+type MessageReturnMinerV2TerminateSectors MessageReturnMinerV0TerminateSectors
+```
+
+#### DeclareFaults
+
+```ipldsch
+type MessageParamsMinerV2DeclareFaults MessageParamsMinerV0DeclareFaults
+type MessageReturnMinerV2DeclareFaults MessageReturnMinerV0DeclareFaults
+```
+
+#### DeclareFaultsRecovered
+
+```ipldsch
+type MessageParamsMinerV2DeclareFaultsRecovered MessageParamsMinerV0DeclareFaultsRecovered
+type MessageReturnMinerV2DeclareFaultsRecovered MessageReturnMinerV0DeclareFaultsRecovered
+```
+
+#### OnDeferredCronEvent
+
+```ipldsch
+type MessageParamsMinerV2OnDeferredCronEvent MessageParamsMinerV0OnDeferredCronEvent
+type MessageReturnMinerV2OnDeferredCronEvent MessageReturnMinerV0OnDeferredCronEvent
+```
+
+#### CheckSectorProven
+
+```ipldsch
+type MessageParamsMinerV2CheckSectorProven MessageParamsMinerV0CheckSectorProven
+type MessageReturnMinerV2CheckSectorProven MessageReturnMinerV0CheckSectorProven
+```
+
+#### ApplyRewards
+
+```ipldsch
+type MessageParamsMinerV2ApplyRewards struct {
+  Reward TokenAmount
+  Penalty TokenAmount
+} representation tuple
+
+type MessageReturnMinerV2ApplyRewards struct {
+} representation tuple
+```
+
+#### ReportConsensusFault
+
+```ipldsch
+type MessageParamsMinerV2ReportConsensusFault MessageParamsMinerV0ReportConsensusFault
+type MessageReturnMinerV2ReportConsensusFault MessageReturnMinerV0ReportConsensusFault
+```
+
+#### WithdrawBalance
+
+```ipldsch
+type MessageParamsMinerV2WithdrawBalance MessageParamsMinerV0WithdrawBalance
+type MessageReturnMinerV2WithdrawBalance MessageReturnMinerV0WithdrawBalance
+```
+
+#### ConfirmSectorProofsValid
+
+```ipldsch
+type MessageParamsMinerV2ConfirmSectorProofsValid MessageParamsMinerV0ConfirmSectorProofsValid
+type MessageReturnMinerV2ConfirmSectorProofsValid MessageReturnMinerV0ConfirmSectorProofsValid
+```
+
+#### ChangeMultiaddrs
+
+```ipldsch
+type MessageParamsMinerV2ChangeMultiaddrs MessageParamsMinerV0ChangeMultiaddrs
+type MessageReturnMinerV2ChangeMultiaddrs MessageReturnMinerV0ChangeMultiaddrs
+```
+
+#### CompactPartitions
+
+```ipldsch
+type MessageParamsMinerV2CompactPartitions MessageParamsMinerV0CompactPartitions
+type MessageReturnMinerV2CompactPartitions MessageReturnMinerV0CompactPartitions
+```
+
+#### CompactSectorNumbers
+
+```ipldsch
+type MessageParamsMinerV2CompactSectorNumbers MessageParamsMinerV0CompactSectorNumbers
+type MessageReturnMinerV2CompactSectorNumbers MessageReturnMinerV0CompactSectorNumbers
+```
+
+#### ConfirmUpdateWorkerKey
+
+```ipldsch
 type MessageParamsMinerV2ConfirmUpdateWorkerKey struct {
 } representation tuple
 
+type MessageReturnMinerV2ConfirmUpdateWorkerKey struct {
+} representation tuple
+```
+
+#### RepayDebt
+
+```ipldsch
 type MessageParamsMinerV2RepayDebt struct {
 } representation tuple
 
-type MessageParamsMinerV2OwnerWorkerAddress Address
+type MessageReturnMinerV2RepayDebt struct {
+} representation tuple
+```
+
+#### ChangeOwnerAddress
+
+```ipldsch
+type MessageParamsMinerV2ChangeOwnerAddress Address
+
+type MessageReturnMinerV2ChangeOwnerAddress struct {
+} representation tuple
 ```
 
 ## MultisigActor
 
+### v0
+
+#### Constructor
+
 ```ipldsch
-type MessageParamsMultisigConstructor struct {
+type MessageParamsMultisigV0Constructor struct {
   Signers [Address]
   NumApprovalsThreshold Int
   UnlockDuration ChainEpoch
   StartEpoch ChainEpoch
 } representation tuple
 
-type MessageParamsMultisigPropose struct {
+type MessageReturnMultisigV0Constructor struct {
+} representation tuple
+```
+
+#### Propose
+
+```ipldsch
+type MessageParamsMultisigV0Propose struct {
   To Address
   Value BigInt
   Method MethodNum
   Params Bytes
 } representation tuple
 
-type MessageParamsMultisigApprove MultisigTransactionID
+type MessageReturnMultisigV0Propose struct {
+  # TxnID is the ID of the proposed transaction
+  TxnID TransactionID
+  # Applied indicates if the transaction was applied as opposed to proposed but not applied due to lack of approvals
+  Applied Bool
+  # Code is the exitcode of the transaction, if Applied is false this field should be ignored.
+  Code ExitCode
+  # Ret is the return vale of the transaction, if Applied is false this field should be ignored.
+  Ret Byte
+} representation tuple
+```
 
-type MessageParamsMultisigCancel MultisigTransactionID
+#### Approve
+
+```ipldsch
+type MessageParamsMultisigV0Approve MultisigTransactionID
 
 type MultisigTransactionID struct {
   ID TransactionID
   ProposeHash Bytes
 } representation tuple
 
-type MessageParamsMultisigAddSigner struct {
+type MessageReturnMultisigV0Approve struct {
+  # Applied indicates if the transaction was applied as opposed to proposed but not applied due to lack of approvals
+  Applied Bool
+  # Code is the exitcode of the transaction, if Applied is false this field should be ignored.
+  Code ExitCode
+  # Ret is the return vale of the transaction, if Applied is false this field should be ignored.
+  Ret Bytes
+} representation tuple
+```
+
+#### Cancel
+
+```ipldsch
+type MessageParamsMultisigV0Cancel MultisigTransactionID
+
+type MessageReturnMultisigV0Cancel struct {
+} representation tuple
+```
+
+#### AddSigner
+
+```ipldsch
+type MessageParamsMultisigV0AddSigner struct {
   Signer Address
   Increase Bool
 } representation tuple
 
-type MessageParamsMultisigRemoveSigner struct {
+type MessageReturnMultisigV0AddSigner struct {
+} representation tuple
+```
+
+#### RemoveSigner
+
+```ipldsch
+type MessageParamsMultisigV0RemoveSigner struct {
   Signer Address
   Decrease Bool
 } representation tuple
 
-type MessageParamsMultisigSwapSigner struct {
+type MessageReturnMultisigV0RemoveSigner struct {
+} representation tuple
+```
+
+#### SwapSigner
+
+```ipldsch
+type MessageParamsMultisigV0SwapSigner struct {
   From Address
   To Address
 } representation tuple
 
-type MessageParamsMultisigChangeThreshold struct {
+type MessageReturnMultisigV0SwapSigner struct {
+} representation tuple
+```
+
+#### ChangeNumApprovalsThreshold
+
+```ipldsch
+type MessageParamsMultisigV0ChangeThreshold struct {
   NewThreshold Int
 } representation tuple
 
-type MessageParamsMultisigLockBalance struct {
+type MessageReturnMultisigV0ChangeThreshold struct {
+} representation tuple
+```
+
+#### LockBalance
+
+```ipldsch
+type MessageParamsMultisigV0LockBalance struct {
   StartEpoch ChainEpoch
   UnlockDuration ChainEpoch
   Amount TokenAmount
 } representation tuple
+
+type MessageReturnMultisigV0LockBalance struct {
+} representation tuple
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsMultisigV2Constructor struct {
+   Signers [addr.Address]
+  NumApprovalsThreshold Int
+  UnlockDuration ChainEpoch
+  StartEpoch ChainEpoch
+} representation tuple
+
+type MessageReturnMultisigV2Constructor MessageReturnMultisigV0Constructor
+```
+
+#### Propose
+
+```ipldsch
+type MessageParamsMultisigV2Propose MessageParamsMultisigV0Propose
+type MessageReturnMultisigV2Propose MessageReturnMultisigV0Propose
+```
+
+#### Approve
+
+```ipldsch
+type MessageParamsMultisigV2Approve MessageParamsMultisigV0Approve
+type MessageReturnMultisigV2Approve MessageReturnMultisigV0Approve
+```
+
+#### Cancel
+
+```ipldsch
+type MessageParamsMultisigV2Cancel MessageParamsMultisigV0ancel
+type MessageReturnMultisigV2Cancel MessageReturnMultisigV0Cancel
+```
+
+#### AddSigner
+
+```ipldsch
+type MessageParamsMultisigV2AddSigner MessageParamsMultisigV0AddSigner
+type MessageReturnMultisigV2AddSigner MessageReturnMultisigV0AddSigner
+```
+
+#### RemoveSigner
+
+```ipldsch
+type MessageParamsMultisigV2RemoveSigner MessageParamsMultisigV0RemoveSigner
+type MessageReturnMultisigV2RemoveSigner MessageReturnMultisigV0RemoveSigner
+```
+
+#### SwapSigner
+
+```ipldsch
+type MessageParamsMultisigV2SwapSigner MessageParamsMultisigV0SwapSigner
+type MessageReturnMultisigV2SwapSigner MessageReturnMultisigV0SwapSigner
+```
+
+#### ChangeNumApprovalsThreshold
+
+```ipldsch
+type MessageParamsMultisigV2ChangeThreshold MessageParamsMultisigV0ChangeThreshold
+type MessageReturnMultisigV2ChangeThreshold MessageReturnMultisigV0ChangeThreshold
+```
+
+#### LockBalance
+
+```ipldsch
+type MessageParamsMultisigV2LockBalance MessageParamsMultisigV0LockBalance
+type MessageReturnMultisigV2LockBalance MessageReturnMultisigV0LockBalance
 ```
 
 ## PaymentChannelActor
 
+### v0
+
+#### Constructor
+
 ```ipldsch
-type MessageParamsPaychConstructor struct {
-  From Address
-  To Address
+type MessageParamsPaychV0Constructor struct {
+  From Address # Payer
+  To Address # Payee
 } representation tuple
 
-type MessageParamsPaychUpdateChannelState struct {
+type MessageReturnPaychV0Constructor struct {
+} representation tuple
+```
+
+#### UpdateChannelState
+
+```ipldsch
+type MessageParamsPaychV0UpdateChannelState struct {
   Sv SignedVoucher
   Secret Bytes
+  Proof Bytes
 } representation tuple
 
+# A voucher is sent by `From` to `To` off-chain in order to enable
+# `To` to redeem payments on-chain in the future
 type SignedVoucher struct {
+  # ChannelAddr is the address of the payment channel this signed voucher is valid for
   ChannelAddr Address
+  # TimeLockMin sets a min epoch before which the voucher cannot be redeemed
   TimeLockMin ChainEpoch
+  # TimeLockMax sets a max epoch beyond which the voucher cannot be redeemed
+  # TimeLockMax set to 0 means no timeout
   TimeLockMax ChainEpoch
+  # (optional) The SecretPreImage is used by `To` to validate
   SecretPreimage optional Bytes
+  # (optional) Extra can be specified by `From` to add a verification method to the voucher
   Extra optional nullable ModVerifyParams
+  # Specifies which lane the Voucher merges into (will be created if does not exist)
   Lane Int
+  # Specifies which lane the Voucher merges into (will be created if does not exist)
   Nonce Int
+  # Amount voucher can be redeemed for
   Amount BigInt
+  # (optional) MinSettleHeight can extend channel MinSettleHeight if needed
   MinSettleHeight optional ChainEpoch
+  # (optional) Set of lanes to be merged into `Lane`
   Merges optional [Merge]
+  # Sender's signature over the voucher
   Signature nullable Signature
 } representation tuple
 
+# Modular Verification method
 type ModVerifyParams struct {
   Method MethodNum
   Params Bytes
@@ -338,20 +1303,82 @@ type Merge struct {
   Nonce Int
 } representation tuple
 
-type MessageParamsPaychSettle struct {
+type MessageReturnPaychV0UpdateChannelState struct {
+} representation tuple
+```
+
+#### Settle
+
+```ipldsch
+type MessageParamsPaychV0Settle struct {
 } representation tuple
 
-type MessageParamsPaychCollect struct {
+type MessageReturnPaychV0Settle struct {
 } representation tuple
+```
+
+#### Collect
+
+```ipldsch
+type MessageParamsPaychV0Collect struct {
+} representation tuple
+
+type MessageReturnPaychV0Collect struct {
+} representation tuple
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsPaychV2Constructor MessageParamsPaychV0Constructor
+type MessageReturnPaychV2Constructor MessageReturnPaychV0Constructor
+```
+
+#### UpdateChannelState
+
+```ipldsch
+type MessageParamsPaychV2UpdateChannelState struct {
+  Sv SignedVoucher
+  Secret Bytes
+} representation tuple
+
+type MessageReturnPaychV2UpdateChannelState MessageReturnPaychV0UpdateChannelState
+```
+
+#### Settle
+
+```ipldsch
+type MessageParamsPaychV2Settle MessageParamsPaychV0Settle
+type MessageReturnPaychV2Settle MessageReturnPaychV0Settle
+```
+
+#### Collect
+
+```ipldsch
+type MessageParamsPaychV2Collect MessageParamsPaychV0Collect
+type MessageReturnPaychV2Collect MessageReturnPaychV0Collect
 ```
 
 ## StoragePowerActor
 
+### v0
+
+#### Constructor
+
 ```ipldsch
-type MessageParamsPowerConstructor struct {
+type MessageParamsPowerV0Constructor struct {
 } representation tuple
 
-type MessageParamsPowerCreateMiner struct {
+type MessageReturnPowerV0Constructor struct {
+} representation tuple
+```
+
+#### CreateMiner
+
+```ipldsch
+type MessageParamsPowerV0CreateMiner struct {
   Owner Address
   Worker Address
   SealProofType RegisteredSealProof
@@ -359,64 +1386,299 @@ type MessageParamsPowerCreateMiner struct {
   Multiaddrs [Multiaddrs]
 } representation tuple
 
-type MessageParamsPowerUpdateClaimedPower struct {
+type MessageReturnPowerV0CreateMine struct {
+  IDAddress Address # The canonical ID-based address for the actor
+  RobustAddress Address # A more expensive but re-org-safe address for the newly created actor
+} representation tuple
+```
+
+#### UpdateClaimedPower
+
+```ipldsch
+type MessageParamsPowerV0UpdateClaimedPower struct {
   RawByteDelta StoragePower
   QualityAdjustedDelta StoragePower
 } representation tuple
 
-type MessageParamsPowerEnrollCronEvent struct {
+type MessageReturnPowerV0UpdateClaimedPower struct {
+} representation tuple
+```
+
+#### EnrollCronEvent
+
+```ipldsch
+type MessageParamsPowerV0EnrollCronEvent struct {
   EventEpoch ChainEpoch
   Payload Bytes
 } representation tuple
 
-type MessageParamsPowerOnEpochTickEnd struct {
+type MessageReturnPowerV0EnrollCronEvent struct {
+} representation tuple
+```
+
+#### OnEpochTickEnd
+
+```ipldsch
+type MessageParamsPowerV0OnEpochTickEnd struct {
 } representation tuple
 
-type MessageParamsPowerUpdatePledgeTotal TokenAmount
+type MessageReturnPowerV0OnEpochTickEnd struct {
+} representation tuple
+```
 
-type MessageParamsPowerOnConsensusFault TokenAmount
+#### UpdatePledgeTotal
 
-type MessageParamsPowerSubmitPoRepForBulkVerify SealVerifyInfo
+```ipldsch
+type MessageParamsPowerV0UpdatePledgeTotal TokenAmount
 
-type MessageParamsPowerCurrentTotal struct {
+type MessageReturnPowerV0UpdatePledgeTotal struct {
+} representation tuple
+```
+
+#### OnConsensusFault
+
+```ipldsch
+type MessageParamsPowerV0OnConsensusFault TokenAmount
+
+type MessageReturnPowerV0OnConsensusFault struct {
+} representation tuple
+```
+
+#### SubmitPoRepForBulkVerify
+
+```ipldsch
+type MessageParamsPowerV0SubmitPoRepForBulkVerify SealVerifyInfo
+
+type MessageReturnPowerV0SubmitPoRepForBulkVerify struct {
+} representation tuple
+```
+
+#### CurrentTotalPower
+
+```ipldsch
+type MessageParamsPowerV0SubmitPoRepForBulkVerify struct {
+} representation tuple
+
+type MessageReturnPowerV0CurrentTotal struct {
   RawBytePower StoragePower
   QualityAdjPower StoragePower
   PledgeCollateral TokenAmount
-  QualityAdjPowerSmoothed V0FilterEstimate
+  QualityAdjPowerSmoothed nullable FilterEstimate
+} representation tuple
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsPowerV2Constructor struct {
+  OwnerAddr Address
+  WorkerAddr Address
+  ControlAddrs [Address]
+  SealProofType RegisteredSealProof
+  PeerId PeerID
+  Multiaddrs [Multiaddrs]
+} representation tuple
+
+type MessageReturnPowerV2Constructor MessageReturnPowerV0Constructor
+```
+
+#### CreateMiner
+
+```ipldsch
+type MessageParamsPowerV2CreateMiner MessageParamsPowerV0CreateMiner
+type MessageReturnPowerV2CreateMine MessageReturnPowerV0CreateMine
+```
+
+#### UpdateClaimedPower
+
+```ipldsch
+type MessageParamsPowerV2UpdateClaimedPower MessageParamsPowerV0UpdateClaimedPower
+type MessageReturnPowerV2UpdateClaimedPower MessageReturnPowerV0UpdateClaimedPower
+```
+
+#### EnrollCronEvent
+
+```ipldsch
+type MessageParamsPowerV2EnrollCronEvent MessageParamsPowerV0EnrollCronEvent
+type MessageReturnPowerV2EnrollCronEvent MessageReturnPowerV0EnrollCronEvent
+```
+
+#### OnEpochTickEnd
+
+```ipldsch
+type MessageParamsPowerV2OnEpochTickEnd MessageParamsPowerV0OnEpochTickEnd
+type MessageReturnPowerV2OnEpochTickEnd MessageReturnPowerV0OnEpochTickEnd
+```
+
+#### UpdatePledgeTotal
+
+```ipldsch
+type MessageParamsPowerV2UpdatePledgeTotal MessageParamsPowerV0UpdatePledgeTotal
+type MessageReturnPowerV2UpdatePledgeTotal MessageReturnPowerV0UpdatePledgeTotal
+```
+
+#### OnConsensusFault
+
+```ipldsch
+type MessageParamsPowerV2OnConsensusFault MessageParamsPowerV0OnConsensusFault
+type MessageReturnPowerV2OnConsensusFault MessageReturnPowerV0OnConsensusFault
+```
+
+#### SubmitPoRepForBulkVerify
+
+```ipldsch
+type MessageParamsPowerV2SubmitPoRepForBulkVerify MessageParamsPowerV0SubmitPoRepForBulkVerify
+type MessageReturnPowerV2SubmitPoRepForBulkVerify MessageReturnPowerV0SubmitPoRepForBulkVerify
+```
+
+#### CurrentTotalPower
+
+```ipldsch
+type MessageParamsPowerV2SubmitPoRepForBulkVerify MessageParamsPowerV2SubmitPoRepForBulkVerify
+
+type MessageReturnPowerV2CurrentTotal struct {
+  RawBytePower StoragePower
+  QualityAdjPower StoragePower
+  PledgeCollateral TokenAmount
+  QualityAdjPowerSmoothed FilterEstimate
 } representation tuple
 ```
 
 ## VerifiedRegistryActor
 
+### v0
+
+#### Constructor
+
+```ipldsch
+type MessageParamsVerifregV0Constructor Address
+
+type MessageReturnVerifregV0Constructor struct {
+} representation tuple
 ```
-type MessageParamsVerifregConstructor Address
 
-type MessageParamsVerifregAddVerifier struct {
+#### AddVerifier
+
+```ipldsch
+type MessageParamsVerifregV0AddVerifier struct {
   Address Address
   Allowance DataCap
 } representation tuple
 
-type MessageParamsVerifregRemoveVerifier Address
+type MessageReturnVerifregV0AddVerifier struct {
+} representation tuple
+```
 
-type MessageParamsVerifregAddVerifiedClient struct {
+#### RemoveVerifier
+
+```ipldsch
+type MessageParamsVerifregV0RemoveVerifier Address
+
+type MessageReturnVerifregV0RemoveVerifier struct {
+} representation tuple
+```
+
+#### AddVerifiedClient
+
+```ipldsch
+type MessageParamsVerifregV0AddVerifiedClient struct {
   Address Address
   Allowance DataCap
 } representation tuple
 
-type MessageParamsVerifregUseBytes struct {
+type MessageReturnVerifregV0AddVerifiedClientstruct struct {
+} representation tuple
+```
+
+#### UseBytes
+
+```ipldsch
+type MessageParamsVerifregV0UseBytes struct {
+  Address Address # Address of verified client
+  DealSize StoragePower # Number of bytes to use
+} representation tuple
+
+type MessageReturnVerifregV0UseBytes struct {
+} representation tuple
+```
+
+#### RestoreBytes
+
+```ipldsch
+type MessageParamsVerifregV0RestoreBytes struct {
   Address Address
   DealSize StoragePower
 } representation tuple
 
-type MessageParamsVerifregRestoreBytes struct {
-  Address Address
-  DealSize StoragePower
+type MessageReturnVerifregV0RestoreBytes struct {
 } representation tuple
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsVerifregV2Constructor MessageParamsVerifregV0Constructor
+type MessageReturnVerifregV2Constructor MessageReturnVerifregV0Constructor
+```
+
+#### AddVerifier
+
+```ipldsch
+type MessageParamsVerifregV2AddVerifier MessageParamsVerifregV0AddVerifier
+type MessageReturnVerifregV2AddVerifier MessageReturnVerifregV0AddVerifier
+```
+
+#### RemoveVerifier
+
+```ipldsch
+type MessageParamsVerifregV2RemoveVerifier MessageParamsVerifregV0RemoveVerifier
+type MessageReturnVerifregV2RemoveVerifier MessageReturnVerifregV0RemoveVerifier
+```
+
+#### AddVerifiedClient
+
+```ipldsch
+type MessageParamsVerifregV2AddVerifiedClient MessageParamsVerifregV0AddVerifiedClient
+type MessageReturnVerifregV2AddVerifiedClientstruct MessageReturnVerifregV0AddVerifiedClientstruct
+```
+
+#### UseBytes
+
+```ipldsch
+type MessageParamsVerifregV2UseBytes MessageParamsVerifregV0UseBytes
+type MessageReturnVerifregV2UseBytes MessageReturnVerifregV0UseBytes
+```
+
+#### RestoreBytes
+
+```ipldsch
+type MessageParamsVerifregV2RestoreBytes MessageParamsVerifregV0RestoreBytes
+type MessageReturnVerifregV2RestoreBytes MessageReturnVerifregV0RestoreBytes
 ```
 
 ## SystemActor
 
+### v0
+
+#### Constructor
+
 ```ipldsch
-type MessageParamsSystemConstructor struct {
+type MessageParamsSystemV0Constructor struct {
 } representation tuple
+
+type MessageReturnSystemV0Constructor struct {
+} representation tuple
+```
+
+### v2
+
+#### Constructor
+
+```ipldsch
+type MessageParamsSystemV2Constructor MessageParamsSystemV0Constructor
+type MessageReturnSystemV2Constructor MessageReturnSystemV0Constructor
 ```

--- a/data-structures/filecoin/messages.md
+++ b/data-structures/filecoin/messages.md
@@ -19,7 +19,7 @@ type MessageParamsInitExec struct {
 
 ## RewardActor
 
-```
+```ipldsch
 type MessageParamsRewardConstructor StoragePower
 
 type MessageParamsRewardAwardBlockReward struct {

--- a/data-structures/filecoin/messages.md
+++ b/data-structures/filecoin/messages.md
@@ -1,0 +1,422 @@
+# Filecoin Messages Data Structures
+
+The following message parameters are encoded as DAG-CBOR and the resulting bytes placed in the `Params` field of the `Message` object.
+
+Each message parameters type is named `MessageParamsActorTypeMessageType`, where `ActorType` is the name of the actor and `MessageType` is the type of message being sent..
+
+## InitActor
+
+```ipldsch
+type MessageParamsInitConstructor struct {
+  NetworkName String
+} representation tuple
+
+type MessageParamsInitExec struct {
+  CodeCID &Any # An inline CID encoded as raw+identity
+  ConstructorParams Bytes
+} representation tuple
+```
+
+## RewardActor
+
+```
+type MessageParamsRewardConstructor StoragePower
+
+type MessageParamsRewardAwardBlockReward struct {
+  Miner Address
+  Penalty TokenAmount
+  GasReward TokenAmount
+  WinCount Int
+} representation tuple
+
+type MessageParamsRewardThisEpochReward struct {
+} representation tuple
+
+type MessageParamsRewardUpdateNetworkKPI StoragePower
+```
+
+## CronActor
+
+```ipldsch
+type MessageParamsCronConstructor struct {
+  Entries [CronV0Entry]
+} representation tuple
+
+type MessageParamsCronEpochTick struct {
+} representation tuple
+```
+
+## AccountActor
+
+```ipldsch
+type MessageParamsAccountConstructor Address
+
+type MessageParamsAccountPubkeyAddress struct {
+} representation tuple
+```
+
+## StorageMarketActor
+
+```ipldsch
+type MessageParamsMarketConstructor struct {
+} representation tuple
+
+type MessageParamsMarketAddBalance Address
+
+type MessageParamsMarketWithdrawBalance struct {
+  ProviderOrClientAmount Address
+  Amount TokenAmount
+} representation tuple
+
+type MessageParamsMarketPublishStorageDeals struct {
+  Deals [MarketClientDealProposal]
+} representation tuple
+
+type MarketClientDealProposal struct {
+  Proposal MarketV0DealProposal
+  ClientSignature Signature
+} representation tuple
+
+type MessageParamsMarketVerifyDealsForActivation struct {
+  DealIDs [DealID]
+  SectorExpiry ChainEpoch
+  SectorStart ChainEpoch
+} representation tuple
+
+type MessageParamsMarketActivateDeals struct {
+  DealIDs [DealID]
+  SectorExpiry ChainEpoch
+} representation tuple
+
+type MessageParamsMarketOnMinerSectorsTerminate struct {
+  Epoch ChainEpoch
+  DealIDs [DealID]
+} representation tuple
+
+type MessageParamsMarketComputeDataCommitment struct {
+  DealIDs [DealID]
+  SectorType RegisteredSealProof
+} representation tuple
+
+type MessageParamsMarketCronTick struct {
+} representation tuple
+```
+
+## StorageMinerActor
+
+```ipldsch
+type MessageParamsMinerConstructor struct {
+  OwnerAddr Address
+  WorkerAddr Address
+  ControlAddrs [Address]
+  SealProofType RegisteredSealProof
+  PeerId PeerID
+  Multiaddrs [Multiaddrs]
+} representation tuple
+
+type MessageParamsMinerControlAddresses struct {
+  NewWorker Address
+  NewControlAddrs [Address]
+} representation tuple
+
+type MessageParamsMinerChangeWorkerAddress struct {
+  NewWorker Address
+  NewControlAddrs [Address]
+} representation tuple
+
+type MessageParamsMinerChangePeerID struct {
+  NewID PeerID
+} representation tuple
+
+type MessageParamsMinerSubmitWindowedPoSt struct {
+  Deadline Int
+  Partitions [MinerPostPartition]
+  Proofs [PoStProof]
+  ChainCommitEpoch ChainEpoch
+  ChainCommitRand Bytes
+} representation tuple
+
+type MinerPostPartition struct {
+  Index Int
+  Skipped BitField
+} representation tuple
+
+type PoStProof struct {
+  PoStProof RegisteredPoStProof
+  ProofBytes Bytes
+} representation tuple
+
+type RegisteredPoStProof int
+
+type MessageParamsMinerPreCommitSector MinerV0SectorPreCommitInfo
+
+type MessageParamsMinerProveCommitSector struct {
+  SectorNumber SectorNumber
+  Proof Bytes
+} representation tuple
+
+type MessageParamsMinerExtendSectorExpiration struct {
+  Extension [MinerExpirationExtend]
+} representation tuple
+
+type MinerExpirationExtend struct {
+  Deadline Int
+  Partition Int
+  Sectors BitField
+  NewExpiration ChainEpoch
+} representation tuple
+
+type MessageParamsMinerTerminateSectors struct {
+  Terminations [MinerTerminationDeclaration]
+} representation tuple
+
+type MinerTerminationDeclaration struct {
+  Deadline Int
+  Partition Int
+  Sectors BitField
+} representation tuple
+
+type MessageParamsMinerDeclareFaults struct {
+  Faults [MinerFaultDeclaration]
+} representation tuple
+
+type MinerFaultDeclaration struct {
+  Deadline Int
+  Partition Int
+  Sectors BitField
+} representation tuple
+
+type MessageParamsMinerDeclareFaultsRecovered struct {
+  Recoveries [MinerRecoveryDeclaration]
+} representation tuple
+
+type MinerRecoveryDeclaration struct {
+  Deadline Int
+  Partition Int
+  Sectors BitField
+} representation tuple
+
+type MessageParamsMinerOnDeferredCronEvent struct {
+  EventType CronEventType
+} representation tuple
+
+type CronEventType int
+
+type MessageParamsMinerCheckSectorProven struct {
+  SectorNumber SectorNumber
+} representation tuple
+
+type MessageParamsMinerV0AddLockedFund TokenAmount
+
+type MessageParamsMinerV2ApplyRewards struct {
+  Reward TokenAmount
+  Penalty TokenAmount
+} representation tuple
+
+type MessageParamsMinerReportConsensusFault struct {
+  BlockHeader1 Bytes
+  BlockHeader2 Bytes
+  BlockHeaderExtra Bytes
+} representation tuple
+
+type MessageParamsMinerWithdrawBalance struct {
+  AmountRequested TokenAmount
+} representation tuple
+
+type MessageParamsMinerConfirmSectorProofsValid struct {
+  Sectors [SectorNumber]
+} representation tuple
+
+type MessageParamsMinerChangeMultiaddrs struct {
+  NewMultiaddrs [Multiaddrs]
+} representation tuple
+
+type MessageParamsMinerCompactPartitions struct {
+  Deadline Int
+  Partitions BitField
+} representation tuple
+
+type MessageParamsMinerCompactSectorNumbers struct {
+  MaskSectorNumbers BitField
+} representation tuple
+
+type MessageParamsMinerV2ConfirmUpdateWorkerKey struct {
+} representation tuple
+
+type MessageParamsMinerV2RepayDebt struct {
+} representation tuple
+
+type MessageParamsMinerV2OwnerWorkerAddress Address
+```
+
+## MultisigActor
+
+```ipldsch
+type MessageParamsMultisigConstructor struct {
+  Signers [Address]
+  NumApprovalsThreshold Int
+  UnlockDuration ChainEpoch
+  StartEpoch ChainEpoch
+} representation tuple
+
+type MessageParamsMultisigPropose struct {
+  To Address
+  Value BigInt
+  Method MethodNum
+  Params Bytes
+} representation tuple
+
+type MessageParamsMultisigApprove MultisigTransactionID
+
+type MessageParamsMultisigCancel MultisigTransactionID
+
+type MultisigTransactionID struct {
+  ID TransactionID
+  ProposeHash Bytes
+} representation tuple
+
+type MessageParamsMultisigAddSigner struct {
+  Signer Address
+  Increase Bool
+} representation tuple
+
+type MessageParamsMultisigRemoveSigner struct {
+  Signer Address
+  Decrease Bool
+} representation tuple
+
+type MessageParamsMultisigSwapSigner struct {
+  From Address
+  To Address
+} representation tuple
+
+type MessageParamsMultisigChangeThreshold struct {
+  NewThreshold Int
+} representation tuple
+
+type MessageParamsMultisigLockBalance struct {
+  StartEpoch ChainEpoch
+  UnlockDuration ChainEpoch
+  Amount TokenAmount
+} representation tuple
+```
+
+## PaymentChannelActor
+
+```ipldsch
+type MessageParamsPaychConstructor struct {
+  From Address
+  To Address
+} representation tuple
+
+type MessageParamsPaychUpdateChannelState struct {
+  Sv SignedVoucher
+  Secret Bytes
+} representation tuple
+
+type SignedVoucher struct {
+  ChannelAddr Address
+  TimeLockMin ChainEpoch
+  TimeLockMax ChainEpoch
+  SecretPreimage optional Bytes
+  Extra optional nullable ModVerifyParams
+  Lane Int
+  Nonce Int
+  Amount BigInt
+  MinSettleHeight optional ChainEpoch
+  Merges optional [Merge]
+  Signature nullable Signature
+} representation tuple
+
+type ModVerifyParams struct {
+  Method MethodNum
+  Params Bytes
+} representation tuple
+
+type Merge struct {
+  Lane Int
+  Nonce Int
+} representation tuple
+
+type MessageParamsPaychSettle struct {
+} representation tuple
+
+type MessageParamsPaychCollect struct {
+} representation tuple
+```
+
+## StoragePowerActor
+
+```ipldsch
+type MessageParamsPowerConstructor struct {
+} representation tuple
+
+type MessageParamsPowerCreateMiner struct {
+  Owner Address
+  Worker Address
+  SealProofType RegisteredSealProof
+  Peer PeerID
+  Multiaddrs [Multiaddrs]
+} representation tuple
+
+type MessageParamsPowerUpdateClaimedPower struct {
+  RawByteDelta StoragePower
+  QualityAdjustedDelta StoragePower
+} representation tuple
+
+type MessageParamsPowerEnrollCronEvent struct {
+  EventEpoch ChainEpoch
+  Payload Bytes
+} representation tuple
+
+type MessageParamsPowerOnEpochTickEnd struct {
+} representation tuple
+
+type MessageParamsPowerUpdatePledgeTotal TokenAmount
+
+type MessageParamsPowerOnConsensusFault TokenAmount
+
+type MessageParamsPowerSubmitPoRepForBulkVerify SealVerifyInfo
+
+type MessageParamsPowerCurrentTotal struct {
+  RawBytePower StoragePower
+  QualityAdjPower StoragePower
+  PledgeCollateral TokenAmount
+  QualityAdjPowerSmoothed V0FilterEstimate
+} representation tuple
+```
+
+## VerifiedRegistryActor
+
+```
+type MessageParamsVerifregConstructor Address
+
+type MessageParamsVerifregAddVerifier struct {
+  Address Address
+  Allowance DataCap
+} representation tuple
+
+type MessageParamsVerifregRemoveVerifier Address
+
+type MessageParamsVerifregAddVerifiedClient struct {
+  Address Address
+  Allowance DataCap
+} representation tuple
+
+type MessageParamsVerifregUseBytes struct {
+  Address Address
+  DealSize StoragePower
+} representation tuple
+
+type MessageParamsVerifregRestoreBytes struct {
+  Address Address
+  DealSize StoragePower
+} representation tuple
+```
+
+## SystemActor
+
+```ipldsch
+type MessageParamsSystemConstructor struct {
+} representation tuple
+```

--- a/data-structures/filecoin/schema.md
+++ b/data-structures/filecoin/schema.md
@@ -1,0 +1,989 @@
+# Filecoin Data Structures
+
+Schemas are grouped by their serialized blocks. Other than those types listed in "Basic Types" and "Crypto Types", each grouping of schema types in a code block represents a data structure that is serialized into a single IPLD block with its own Link (CID).
+
+Advanced Data Layouts (ADLs) are shown in their expanded form here, as the data appears on-block. Their logical forms for programmatic purposes are `Map` for the HAMT and `List` for the AMT.
+
+There are some data structures that are repeats of the same forms, primarily the AMT and HAMTs that share the same data types. They are not de-duplicated here for clarity to demonstrate the different purposes of those data structures.
+
+For more information about the IPLD Schema language, see the [specificaiton](https://specs.ipld.io/schemas/).
+
+## Basic Types
+
+```ipldsch
+type Address bytes
+
+# Used as a fudge to get arbitrary bytes into map keys
+type RawAddress string
+
+type CidString string
+
+type BigInt bytes # Go big.Int
+
+type MethodNum int
+
+type ActorID int
+
+type ChainEpoch int
+
+type TokenAmount BigInt
+
+type UnpaddedPieceSize int # TODO: where is this used?
+
+type PaddedPieceSize int
+
+type PeerID bytes
+
+type SectorSize int
+
+type SectorNumber int
+
+type PartitionNumber int
+
+type BitField bytes
+
+type StoragePower BigInt
+
+type DealID int
+
+type DealWeight BigInt
+
+type Multiaddr bytes
+
+type RegisteredSealProof int
+
+type TransactionID # TxnID
+```
+
+TODO: where is `SealVerifyInfo` used?
+
+## Crypto Types
+
+```ipldsch
+type Signature union {
+  SignatureSecp256k1 0 # TODO: check the prefix bytes
+  SignatureBLS 1
+} representation byteprefix
+```
+
+## Genesis Block
+
+```ipldsch
+type Genesis struct {
+  Datetime String
+  Network String
+  Token String
+  TokenAmounts TokenAmounts
+  Message String
+}
+
+type TokenAmounts struct {
+  TotalSupply String
+  Miners String
+  ProtocolLabs {String:String}
+}
+```
+
+## Chain
+
+```ipldsch
+type BlockHeader struct {
+  Miner Address
+  Ticket nullable Ticket
+  ElectionProof nullable ElectionProof
+  BeaconEntries [BeaconEntry]
+  WinPoStProof [PoStProof]
+  Parents [&Any] # TODO: can we &BlockHeader this or is it a union with Genesis?
+  ParentWeight Bytes
+  Height ChainEpoch
+  ParentStateRoot &StateRoot
+  ParentMessageReceipts &Any # TODO: specs suggest this is an AMT of `MessageReceipt`
+  Messages &TxMeta
+  BLSAggregate nullable Signature
+  Timestamp Int
+  BlockSig nullable Signature
+  ForkSignaling Int
+  ParentBaseFee TokenAmount
+} representation tuple
+
+type Ticket struct {
+  VRFProof Bytes
+} representation tuple
+
+type ElectionProof struct {
+  WinCount Int
+  VRFProof Bytes
+} representation tuple
+
+type BeaconEntry struct {
+  Round Int
+  Data Bytes
+} representation tuple
+
+type PoStProof struct {
+  PoStProof Int
+  ProofBytes Bytes
+} representation tuple
+```
+
+TODO: I haven't seen this, is it correct? Apparently in an AMT?
+
+```ipldsch
+type ExitCode int
+type MessageReceipt struct {
+  ExitCode ExitCode
+  Return   Bytes
+  GasUsed  Int
+} representation tuple
+```
+
+```ipldsch
+type StateRoot struct {
+  Version Int
+  Actors &ActorsHAMT
+  Info &Any # TODO: what does this point to?
+} representation tuple
+```
+
+## Messages
+
+```ipldsch
+type TxMeta struct {
+  BlsMessages &MessageLinkAMT
+  SecpkMessages &SignedMessageLinkAMT
+} representation tuple
+
+```ipldsch
+type Message struct {
+  Version Int
+  To Address
+  From Address
+  Nonce Int
+  Value BigInt
+  GasLimit Int
+  GasFeeCap BigInt
+  GasPremium BigInt
+  Method MethodNum
+  Params Bytes
+} representation tuple
+
+type SignedMessage struct {
+  Message Message
+  Signature Signature
+} representation tuple
+```
+
+**AMT**: This is an ADL representing `type MessagesList [&Message]`.
+
+```ipldsch
+type MessageLinkAMT struct {
+  height Int
+  count Int
+  node MessageLinkAMTNode
+} representation tuple
+
+# This can also be the root of a block
+type MessageLinkAMTNode struct {
+  bitmap Bytes
+  children [&MessageLinkAMTNode]
+  values [&Message]
+} representation tuple
+```
+
+**AMT**: This is an ADL representing `type SignedMessagesList [&SignedMessage]`.
+
+Note this is identical in layout to `MessagesList` and contains links at the leaves, but is listed here for completeness.
+
+```ipldsch
+type SignedMessageLinkAMT struct {
+  height Int
+  count Int
+  node SignedMessageLinkAMTNode
+} representation tuple
+
+# This can also be the root of a block
+type SignedMessageLinkAMTNode struct {
+  bitmap Bytes
+  children [&SignedMessageLinkAMTNode]
+  values [&SignedMessage]
+} representation tuple
+```
+
+## Actors
+
+**HAMT**: This is an ADL representing `type ActorsMap {RawAddress:Actors}`.
+
+```ipldsch
+type ActorsHAMT struct {
+  map Bytes
+  data [ ActorsHAMTElement ]
+} representation tuple
+
+type ActorsHAMTElement union {
+  | ActorsHAMTLink "0"
+  | ActorsHAMTBucket "1"
+} representation keyed
+
+type ActorsHAMTLink &ActorsHAMT
+
+type ActorsHAMTBucket [ ActorsHAMTBucketEntry ]
+
+type ActorsHAMTBucketEntry struct {
+  key Bytes # RawAddress bytes
+  value Actor # inline
+} representation tuple
+
+type Actor struct {
+  code &Any # An inline CID encoded as raw+identity
+  head &Any # TODO: Is this where the various actor types get linked?
+  nonce Int # TODO: Should this be "CallSeqNum"?
+  balance Bytes
+} representation tuple
+```
+
+### InitActor
+
+```ipldsch
+type InitV0State struct {
+  AddressMap &ActorIDHAMT # TODO: confirm this is actually a HAMT here (defined below)
+  NextID ActorID
+  NetworkName String
+} representation tuple
+```
+
+**HAMT**: This is an ADL representing `type ActorIDHAMT {RawAddress:ActorID}`.
+
+Note that this HAMT block form is indistinguishable from `DealIDHAMT` and `BalanceTableHAMT` which are also `{String:Int}`.
+
+```ipldsch
+type ActorIDHAMT struct {
+  map Bytes
+  data [ ActorIDHAMTElement ]
+} representation tuple
+
+type ActorIDHAMTElement union {
+  | ActorIDHAMTLink "0"
+  | ActorIDHAMTBucket "1"
+} representation keyed
+
+type ActorIDHAMTLink &ActorIDHAMT
+
+type ActorIDHAMTBucket [ ActorIDHAMTBucketEntry ]
+
+type ActorIDHAMTBucketEntry struct {
+  key Bytes # RawAddress
+  value ActorID
+} representation tuple
+```
+
+### CronActor
+
+```ipldsch
+type CronV0State struct {
+  Entries [CronV0Entry]
+} representation tuple
+
+type CronV0Entry struct {
+  Receiver Address
+  MethodNum MethodNum
+} representation tuple
+```
+
+### RewardActor
+
+**v0**
+
+```ipldsch
+type Spacetime bytes
+
+type RewardV0State struct {
+  CumsumBaseline Spacetime
+  CumsumRealized Spacetime
+  EffectiveNetworkTime ChainEpoch
+  EffectiveBaselinePower StoragePower
+  ThisEpochReward TokenAmount
+  ThisEpochRewardSmoothed nullable V0FilterEstimate
+  ThisEpochBaselinePower StoragePower
+  Epoch ChainEpoch
+  TotalMined TokenAmount
+} representation tuple
+
+type V0FilterEstimate struct {
+  PositionEstimate BigInt
+  VelocityEstimate BigInt
+} representation tuple
+```
+
+**v2**
+
+```ipldsch
+type RewardV2State struct {
+  CumsumBaseline Spacetime
+  CumsumRealized Spacetime
+  EffectiveNetworkTime ChainEpoch
+  EffectiveBaselinePower StoragePower
+  ThisEpochReward TokenAmount
+  ThisEpochRewardSmoothed V0FilterEstimate
+  ThisEpochBaselinePower StoragePower
+  Epoch ChainEpoch
+  TotalStoragePowerReward TokenAmount
+  SimpleTotal BigInt
+  BaselineTotal BigInt
+} representation tuple
+```
+
+### AccountActor
+
+```ipldsch
+type AccountV0State struct {
+  Address Address
+} representation tuple
+```
+
+### StorageMarketActor
+
+```ipldsch
+type MarketV0State struct {
+  Proposals &DealProposalAMT # AMT[DealID]DealProposal
+  States &DealStateAMT # AMT[DealID]DealState
+  PendingProposals &MarketV0DealProposalHAMT # HAMT[DealCid]DealProposal
+  EscrowTable &BalanceTableHAMT # HAMT[Address]TokenAmount
+  LockedTable &BalanceTableHAMT # HAMT[Address]TokenAmount
+  NextID DealID
+  DealOpsByEpoch &DealOpsByEpochHAMT # SetMultimap: HAMT[ChainEpoch]Set[DealID]
+  LastCron ChainEpoch
+  TotalClientLockedCollateral TokenAmount
+  TotalProviderLockedCollateral TokenAmount
+  TotalClientStorageFee TokenAmount
+} representation tuple
+```
+
+**AMT**: This is an ADL representing `type DealProposalList [DealProposal]`, indexed by `DealID`.
+
+```ipldsch
+type DealProposalAMT struct {
+  height Int
+  count Int
+  node DealProposalAMTNode
+} representation tuple
+
+type DealProposalAMTNode struct {
+  bitmap Bytes
+  children [&DealProposalAMTNode]
+  values [MarketV0DealProposal] # inline
+} representation tuple
+
+type MarketV0DealProposal struct {
+  PieceCID &Any # A CID with fil-commitment-unsealed + sha2_256-trunc254-padded
+  PieceSize PaddedPieceSize
+  VerifiedDeal Bool
+  Client Address
+  Provider Address
+  Label String
+  StartEpoch ChainEpoch
+  EndEpoch ChainEpoch
+  StoragePricePerEpoch TokenAmount
+  ProviderCollateral TokenAmount
+  ClientCollateral TokenAmount
+} representation tuple
+```
+
+**AMT**: This is an ADL representing `type DealProposalList [DealState]`, indexed by `DealID`.
+
+```ipldsch
+type DealStateAMT struct {
+  height Int
+  count Int
+  node DealStateAMTNode
+} representation tuple
+
+type DealStateAMTNode struct {
+  bitmap Bytes
+  children [&DealStateAMTNode]
+  values [MarketV0DealState] # inline
+} representation tuple
+
+type MarketV0DealState struct {
+  SectorStartEpoch ChainEpoch
+  LastUpdatedEpoch ChainEpoch
+  SlashEpoch ChainEpoch
+} representation tuple
+```
+
+**HAMT**: This is an ADL representing `type ActorsMap {DealCidBytes:Actors}`.
+
+```ipldsch
+type DealCidBytes bytes
+
+type MarketV0DealProposalHAMT struct {
+  map Bytes
+  data [ MarketV0DealProposalHAMTElement ]
+} representation tuple
+
+type MarketV0DealProposalHAMTElement union {
+  | MarketV0DealProposalHAMTLink "0"
+  | Bucket "1"
+} representation keyed
+
+type MarketV0DealProposalHAMTLink &MarketV0DealProposalHAMT
+
+type MarketV0DealProposalHAMTBucket [ MarketV0DealProposalHAMTBucketEntry ]
+
+type MarketV0DealProposalHAMTBucketEntry struct {
+  key DealCidBytes
+  value MarketV0DealProposal
+} representation tuple
+
+type MarketV0DealProposal struct {
+  PieceCID &Any # A CID with fil-commitment-unsealed + sha2_256-trunc254-padded
+  PieceSize PaddedPieceSize
+  VerifiedDeal Bool
+  Client Address
+  Provider Address
+  Label String
+  StartEpoch ChainEpoch
+  EndEpoch ChainEpoch
+  StoragePricePerEpoch TokenAmount
+  ProviderCollateral TokenAmount
+  ClientCollateral TokenAmount
+} representation tuple
+```
+
+**HAMT**: This is an ADL representing `type BalanceTable {RawAddress:TokenAmount}`.
+
+Note that this HAMT block form is indistinguishable from `ActorIDHAMT` and `DealIDHAMT` which are also `{String:Int}`.
+
+```ipldsch
+type BalanceTableHAMT struct {
+  map Bytes
+  data [ BalanceTableHAMTElement ]
+} representation tuple
+
+type BalanceTableHAMTElement union {
+  | BalanceTableHAMTLink "0"
+  | BalanceTableHAMTBucket "1"
+} representation keyed
+
+type BalanceTableHAMTLink &BalanceTableHAMT
+
+type BalanceTableHAMTBucket [ BalanceTableHAMTBucketEntry ]
+
+type BalanceTableHAMTBucketEntry struct {
+  key Bytes # RawAddress
+  value TokenAmount
+} representation tuple
+```
+
+**SetMultimap (HAMT+HAMT)**: This is an ADL representing a Set within a Map `type DealOpsByEpoch {ChainEpochString:{DealID:Null}}` where `ChainEpochString` is a text form of the `ChainEpoch` integer and `DealIDString` is the bytes of a uvarint form of `DealID`.
+
+```ipldsch
+# HAMT/map root structure
+
+type DealOpsByEpochHAMT struct {
+  map Bytes
+  data [ DealOpsByEpochHAMTElement ]
+} representation tuple
+
+type DealOpsByEpochHAMTElement union {
+  | DealOpsByEpochHAMTLink "0"
+  | DealOpsByEpochHAMTBucket "1"
+} representation keyed
+
+type DealOpsByEpochHAMTLink &DealOpsByEpochHAMTLink
+
+type DealOpsByEpochHAMTBucket [ DealOpsByEpochHAMTBucketEntry ]
+
+type DealOpsByEpochHAMTBucketEntry struct {
+  key Bytes
+  value &DealOpsByEpochAMT
+} representation tuple
+
+# HAMT/set leaf structure (map of nulls)
+
+type DealOpsByEpochHAMTSet struct {
+  map Bytes
+  data [ DealOpsByEpochHAMTSetElement ]
+} representation tuple
+
+type DealOpsByEpochHAMTSetElement union {
+  | DealOpsByEpochHAMTSet_Link "0"
+  | DealOpsByEpochHAMTSetBucket "1"
+} representation keyed
+
+type DealOpsByEpochHAMTSet_Link &DealOpsByEpochHAMTSet
+
+type DealOpsByEpochHAMTSetBucket [ DealOpsByEpochHAMTSetBucketEntry ]
+
+type DealOpsByEpochHAMTSetBucketEntry struct {
+  key Bytes # The bytes of the string form of ChainEpoch
+  value Null
+} representation tuple
+```
+
+### StorageMarketActor
+
+```ipldsch
+type MinerV0State struct {
+  Info  &MinerV0Info
+  PreCommitDeposits TokenAmount
+  LockedFunds TokenAmount
+  VestingFunds &MinerV0VestingFunds
+  InitialPledge TokenAmount
+  PreCommittedSectors &MinerV0SectorPreCommitOnChainInfoHAMT # HAMT[SectorNumber]SectorPreCommitOnChainInfo
+  PreCommittedSectorsExpiry &BitFieldQueueAMT # AMT[ChainEpoch]BitField
+  AllocatedSectors &BitField
+  Sectors &MinerV0SectorOnChainInfoAMT # AMT[SectorNumber]SectorOnChainInfo
+  ProvingPeriodStart ChainEpoch
+  CurrentDeadline Int
+  Deadlines &MinerV0Deadlines
+  EarlyTerminations BitField
+} representation tuple
+```
+
+**v2**
+
+```ipldsch
+type MinerV2State struct {
+  Info  &MinerV2Info
+  PreCommitDeposits TokenAmount
+  LockedFunds TokenAmount
+  VestingFunds &MinerV0VestingFunds
+  FeeDebt TokenAmount
+  InitialPledge TokenAmount
+  PreCommittedSectors &MinerV0SectorPreCommitOnChainInfoHAMT # HAMT[SectorNumber]SectorPreCommitOnChainInfo
+  PreCommittedSectorsExpiry &BitFieldQueueAMT # AMT[ChainEpoch]BitField
+  AllocatedSectors &BitField
+  Sectors &MinerV0SectorOnChainInfoAMT # AMT[SectorNumber]SectorOnChainInfo
+  ProvingPeriodStart ChainEpoch
+  CurrentDeadline Int
+  Deadlines &MinerV2Deadlines
+  EarlyTerminations BitField
+} representation tuple
+```
+
+```ipldsch
+type MinerV0Info struct {
+  Owner Address
+  Worker Address
+  ControlAddresses nullable [Address]
+  PendingWorkerKey nullable MinerV0WorkerChangeKey
+  PeerId PeerID
+  Multiaddrs nullable [Multiaddr]
+  SealProofType Int
+  SectorSize SectorSize
+  WindowPoStPartitionSectors Int
+} representation tuple
+
+type MinerV0WorkerChangeKey struct {
+  NewWorker Address
+  EffectiveAt ChainEpoch
+} representation tuple
+```
+
+**v2**
+
+```ipldsch
+type MinerV2Info struct {
+  Owner Address
+  Worker Address
+  ControlAddresses nullable [Address]
+  PendingWorkerKey nullable MinerV0WorkerChangeKey
+  PeerId PeerID
+  Multiaddrs nullable [Multiaddr]
+  SealProofType Int
+  SectorSize SectorSize
+  WindowPoStPartitionSectors Int
+  ConsensusFaultElapsed ChainEpoch
+  PendingOwnerAddress nullable Address
+} representation tuple
+```
+
+```ipldsch
+type MinerV0VestingFunds struct {
+  Funds [MinerV0VestingFund]
+} representation tuple
+
+type MinerV0VestingFund struct {
+  Epoch ChainEpoch
+  Amount TokenAmount
+} representation tuple
+```
+
+```ipldsch
+type MinerV0Deadlines struct {
+  Due MinerV0DeadlineLinkList
+} representation tuple
+
+# Must be 48 CIDs
+type MinerV0DeadlineLinkList struct {
+  deadline1 &MinerV0Deadline
+  deadline2 &MinerV0Deadline
+  deadline3 &MinerV0Deadline
+  deadline4 &MinerV0Deadline
+  deadline5 &MinerV0Deadline
+  deadline6 &MinerV0Deadline
+  deadline7 &MinerV0Deadline
+  deadline8 &MinerV0Deadline
+  deadline9 &MinerV0Deadline
+  deadline10 &MinerV0Deadline
+  deadline11 &MinerV0Deadline
+  deadline12 &MinerV0Deadline
+  deadline13 &MinerV0Deadline
+  deadline14 &MinerV0Deadline
+  deadline15 &MinerV0Deadline
+  deadline16 &MinerV0Deadline
+  deadline17 &MinerV0Deadline
+  deadline18 &MinerV0Deadline
+  deadline19 &MinerV0Deadline
+  deadline20 &MinerV0Deadline
+  deadline21 &MinerV0Deadline
+  deadline22 &MinerV0Deadline
+  deadline23 &MinerV0Deadline
+  deadline24 &MinerV0Deadline
+  deadline25 &MinerV0Deadline
+  deadline26 &MinerV0Deadline
+  deadline27 &MinerV0Deadline
+  deadline28 &MinerV0Deadline
+  deadline29 &MinerV0Deadline
+  deadline30 &MinerV0Deadline
+  deadline31 &MinerV0Deadline
+  deadline32 &MinerV0Deadline
+  deadline33 &MinerV0Deadline
+  deadline34 &MinerV0Deadline
+  deadline35 &MinerV0Deadline
+  deadline36 &MinerV0Deadline
+  deadline37 &MinerV0Deadline
+  deadline38 &MinerV0Deadline
+  deadline39 &MinerV0Deadline
+  deadline40 &MinerV0Deadline
+  deadline41 &MinerV0Deadline
+  deadline42 &MinerV0Deadline
+  deadline43 &MinerV0Deadline
+  deadline44 &MinerV0Deadline
+  deadline45 &MinerV0Deadline
+  deadline46 &MinerV0Deadline
+  deadline47 &MinerV0Deadline
+  deadline48 &MinerV0Deadline
+} representation tuple
+```
+
+**v2** (same form as `MinerV0Deadlines` but the eventual link to `MinerV2Partition` is different.)
+
+```ipldsch
+type MinerV2Deadlines struct {
+  Due MinerV2DeadlineLinkList
+} representation tuple
+
+# Must be 48 CIDs
+type MinerV2DeadlineLinkList struct {
+  deadline1 &MinerV2Deadline
+  deadline2 &MinerV2Deadline
+  deadline3 &MinerV2Deadline
+  deadline4 &MinerV2Deadline
+  deadline5 &MinerV2Deadline
+  deadline6 &MinerV2Deadline
+  deadline7 &MinerV2Deadline
+  deadline8 &MinerV2Deadline
+  deadline9 &MinerV2Deadline
+  deadline10 &MinerV2Deadline
+  deadline11 &MinerV2Deadline
+  deadline12 &MinerV2Deadline
+  deadline13 &MinerV2Deadline
+  deadline14 &MinerV2Deadline
+  deadline15 &MinerV2Deadline
+  deadline16 &MinerV2Deadline
+  deadline17 &MinerV2Deadline
+  deadline18 &MinerV2Deadline
+  deadline19 &MinerV2Deadline
+  deadline20 &MinerV2Deadline
+  deadline21 &MinerV2Deadline
+  deadline22 &MinerV2Deadline
+  deadline23 &MinerV2Deadline
+  deadline24 &MinerV2Deadline
+  deadline25 &MinerV2Deadline
+  deadline26 &MinerV2Deadline
+  deadline27 &MinerV2Deadline
+  deadline28 &MinerV2Deadline
+  deadline29 &MinerV2Deadline
+  deadline30 &MinerV2Deadline
+  deadline31 &MinerV2Deadline
+  deadline32 &MinerV2Deadline
+  deadline33 &MinerV2Deadline
+  deadline34 &MinerV2Deadline
+  deadline35 &MinerV2Deadline
+  deadline36 &MinerV2Deadline
+  deadline37 &MinerV2Deadline
+  deadline38 &MinerV2Deadline
+  deadline39 &MinerV2Deadline
+  deadline40 &MinerV2Deadline
+  deadline41 &MinerV2Deadline
+  deadline42 &MinerV2Deadline
+  deadline43 &MinerV2Deadline
+  deadline44 &MinerV2Deadline
+  deadline45 &MinerV2Deadline
+  deadline46 &MinerV2Deadline
+  deadline47 &MinerV2Deadline
+  deadline48 &MinerV2Deadline
+} representation tuple
+```
+
+```ipldsch
+type MinerV0Deadline struct {
+  Partitions &MinerV0PartitionAMT # AMT[PartitionNumber]Partition
+  ExpirationEpochs &BitFieldQueueAMT # AMT[ChainEpoch]BitField
+  PostSubmissions BitField
+  EarlyTerminations BitField
+  LiveSectors Int
+  TotalSectors Int
+  FaultyPower MinerV0PowerPair
+} representation tuple
+```
+
+**v2**
+
+```ipldsch
+type MinerV2Deadline struct {
+  Partitions &MinerV2PartitionAMT # AMT[PartitionNumber]Partition
+  ExpirationEpochs &BitFieldQueueAMT # AMT[ChainEpoch]BitField
+  PostSubmissions BitField
+  EarlyTerminations BitField
+  LiveSectors Int
+  TotalSectors Int
+  FaultyPower MinerV0PowerPair
+} representation tuple
+```
+
+**HAMT**: This is an ADL representing `type SectorPreCommitOnChainInfoMap {SectorNumberString:SectorPreCommitOnChainInfo}`. Where SectorNumberString is the uvarint bytes (string) form of `SectorNumber`.
+
+```ipldsch
+type MinerV0SectorPreCommitOnChainInfoHAMT struct {
+  map Bytes
+  data [ MinerV0SectorPreCommitOnChainInfoHAMTElement ]
+} representation tuple
+
+type MinerV0SectorPreCommitOnChainInfoHAMTElement union {
+  | MinerV0SectorPreCommitOnChainInfoHAMTLink "0"
+  | MinerV0SectorPreCommitOnChainInfoHAMTBucket "1"
+} representation keyed
+
+type MinerV0SectorPreCommitOnChainInfoHAMTLink &MinerV0SectorPreCommitOnChainInfoHAMT
+
+type MinerV0SectorPreCommitOnChainInfoHAMTBucket [ MinerV0SectorPreCommitOnChainInfoHAMTBucketEntry ]
+
+type MinerV0SectorPreCommitOnChainInfoHAMTBucketEntry struct {
+  key Bytes
+  value MinerV0SectorPreCommitOnChainInfo # inline
+} representation tuple
+
+type MinerV0SectorPreCommitOnChainInfo struct {
+  Info MinerV0SectorPreCommitInfo
+  PreCommitDeposit TokenAmount
+  PreCommitEpoch ChainEpoch
+  DealWeight DealWeight
+  VerifiedDealWeight DealWeight
+} representation tuple
+
+type MinerV0SectorPreCommitInfo struct {
+  SealProof RegisteredSealProof
+  SectorNumber SectorNumber
+  SealedCID &Any # A CID with fil-commitment-sealed + poseidon-bls12_381-ac-fc1
+  SealRandEpoch ChainEpoch
+  DealIDs [DealID]
+  Expiration ChainEpoch
+  ReplaceCapacity Bool
+  ReplaceSectorDeadline Int
+  ReplaceSectorPartition PartitionNumber
+  ReplaceSectorNumber SectorNumber
+} representation tuple
+```
+
+**AMT**: This is an ADL representing `type BitFieldQueue [BitField]` indexed by `ChainEpoch`.
+
+```ipldsch
+type BitFieldQueueAMT struct {
+  height Int
+  count Int
+  node BitFieldQueueAMTNode
+} representation tuple
+
+type BitFieldQueueAMTNode struct {
+  bitmap Bytes
+  children [&BitFieldQueueAMTNode]
+  values [Bitfield]
+} representation tuple
+```
+
+**AMT**: This is an ADL representing `type SectorOnChainInfoList [SectorOnChainInfo]` indexed by `SectorNumber`.
+
+```ipldsch
+type MinerV0SectorOnChainInfoAMT struct {
+  height Int
+  count Int
+  node MinerV0SectorOnChainInfoAMTNode
+} representation tuple
+
+type MinerV0SectorOnChainInfoAMTNode struct {
+  bitmap Bytes
+  children [&MinerV0SectorOnChainInfoAMTNode]
+  values [MinerV0SectorOnChainInfo]
+} representation tuple
+
+type MinerV0SectorOnChainInfo struct {
+  SectorNumber SectorNumber
+  SealProof RegisteredSealProof
+  SealedCID &Any # A CID with fil-commitment-sealed + poseidon-bls12_381-ac-fc1
+  DealIDs [DealID]
+  Activation ChainEpoch
+  Expiration ChainEpoch
+  DealWeight DealWeight
+  VerifiedDealWeight DealWeight
+  InitialPledge TokenAmount
+  ExpectedDayReward TokenAmount
+  ExpectedStorageReward TokenAmount
+  ReplacedSectorAge ChainEpoch
+  ReplacedDayReward TokenAmount
+} representation tuple
+```
+
+**AMT**: This is an ADL representing `type MinerV0PartitionList [MinerV0Partition]` indexed by `PartitionNumber`.
+
+```ipldsch
+type MinerV0PartitionAMT struct {
+  height Int
+  count Int
+  node MinerV0PartitionAMTNode
+} representation tuple
+
+type MinerV0PartitionAMTNode struct {
+  bitmap Bytes
+  children [&MinerV0PartitionAMTNode]
+  values [MinerV0Partition]
+} representation tuple
+
+type MinerV0Partition struct {
+  Sectors BitField
+  Faults BitField
+  Recoveries BitField
+  Terminated BitField
+  ExpirationsEpochs &MinerV0ExpirationSetAMT # AMT[ChainEpoch]ExpirationSet
+  EarlyTerminated &BitFieldQueueAMT # AMT[ChainEpoch]BitField
+  LivePower MinerV0PowerPair
+  FaultyPower MinerV0PowerPair
+  RecoveringPower MinerV0PowerPair
+} representation tuple
+
+type MinerV0PowerPair struct {
+  Raw StoragePower
+  QA StoragePower
+} representation tuple
+```
+
+**v2**
+
+**AMT**: This is an ADL representing `type MinerV2PartitionList [MinerV2Partition]` indexed by `PartitionNumber`.
+
+```ipldsch
+type MinerV2PartitionAMT struct {
+  height Int
+  count Int
+  node MinerV2PartitionAMTNode
+} representation tuple
+
+type MinerV2PartitionAMTNode struct {
+  bitmap Bytes
+  children [&MinerV2PartitionAMTNode]
+  values [MinerV2Partition]
+} representation tuple
+
+type MinerV2Partition struct {
+  Sectors BitField
+  Unproven BitField
+  Faults BitField
+  Recoveries BitField
+  Terminated BitField
+  ExpirationsEpochs &MinerV0ExpirationSetAMT # AMT[ChainEpoch]ExpirationSet
+  EarlyTerminated &BitFieldQueueAMT # AMT[ChainEpoch]BitField
+  LivePower MinerV0PowerPair
+  UnprovenPower MinerV0PowerPair
+  FaultyPower MinerV0PowerPair
+  RecoveringPower MinerV0PowerPair
+} representation tuple
+```
+
+**AMT**: This is an ADL representing `type MinerV0ExpirationSetList [MinerV0ExpirationSet]` indexed by `ChainEpoch`.
+
+```ipldsch
+type MinerV0ExpirationSetAMT struct {
+  height Int
+  count Int
+  node MinerV0ExpirationSetAMTNode
+} representation tuple
+
+type MinerV0ExpirationSetAMTNode struct {
+  bitmap Bytes
+  children [&MinerV0ExpirationSetAMTNode]
+  values [MinerV0ExpirationSet]
+} representation tuple
+
+type MinerV0ExpirationSet struct {
+  OnTimeSectors BitField
+  EarlySectors BitField
+  OnTimePledge TokenAmount
+  ActivePower MinerV0PowerPair
+  FaultyPower MinerV0PowerPair
+} representation tuple
+```
+
+### MultisigActor
+
+```ipldsch
+type MultisigV0State struct {
+  Signers [Address]
+  NumApprovalsThreshold Int
+  NextTxnID TransactionID
+  InitialBalance TokenAmount
+  StartEpoch ChainEpoch
+  UnlockDuration ChainEpoch
+  PendingTxns &MultisigV0TransactionHAMT # HAMT[TransactionID]Multisigv0Transaction
+} representation tuple
+```
+
+**HAMT**: This is an ADL representing `type MultisigV0TransactionMap {TransactionIDString:MultisigV0Transaction}`. Where TransactionIDString is the varint (not uvarint) bytes (string) form of `TransactionID`.
+
+```ipldsch
+type MultisigV0TransactionHAMT struct {
+  map Bytes
+  data [ MultisigV0TransactionHAMTElement ]
+} representation tuple
+
+type MultisigV0TransactionHAMTElement union {
+  | MultisigV0TransactionHAMTLink "0"
+  | MultisigV0TransactionHAMTBucket "1"
+} representation keyed
+
+type MultisigV0TransactionHAMTLink &MultisigV0TransactionHAMT
+
+type MultisigV0TransactionHAMTBucket [ MultisigV0TransactionHAMTBucketEntry ]
+
+type MultisigV0TransactionHAMTBucketEntry struct {
+  key Bytes
+  value MultisigV0Transaction # inline
+} representation tuple
+
+type MultisigV0Transaction struct {
+  To Address
+  Value TokenAmount
+  Method MethodNum
+  Params Bytes
+  Approved [Address]
+} representation tuple
+```
+
+### PaymentChannelActor
+
+### StoragePowerActor
+
+### VerifiedRegistryActor
+
+### SystemActor
+

--- a/data-structures/filecoin/schema.md
+++ b/data-structures/filecoin/schema.md
@@ -983,9 +983,73 @@ type MultisigV0Transaction struct {
 
 ### PaymentChannelActor
 
+```
+type PaychV0State struct {
+  From Address
+  To Address
+  ToSend BigInt
+  SettlingAt ChainEpoch
+  MinSettleHeight ChainEpoch
+  LaneStates &PaychV0LaneStatesAMT # AMT[Int]PaychV0LaneState
+} representation tuple
+```
+
+**AMT**: This is an ADL representing `type PaychV0LaneStates [PaychV0LaneState]` indexed by Lane ID.
+
+```ipldsch
+type PaychV0LaneStatesAMT struct {
+  height Int
+  count Int
+  node PaychV0LaneStatesAMTNode
+} representation tuple
+
+type PaychV0LaneStatesAMTNode struct {
+  bitmap Bytes
+  children [&PaychV0LaneStatesAMTNode]
+  values [PaychV0LaneState]
+} representation tuple
+
+type PaychV0LaneState struct {
+  Redeemed BigInt
+  Nonce Int
+} representation tuple
+```
+
 ### StoragePowerActor
 
 ### VerifiedRegistryActor
 
+```ipldsch
+type VerifregV0State struct {
+  RootKey Address
+  Verifiers &DataCapHAMT
+  VerifiedClients &DataCapHAMT
+}
+```
+
+**HAMT**: This is an ADL representing `type DataCapMap {Address:StoragePower}`.
+
+```ipldsch
+type DataCapHAMT struct {
+  map Bytes
+  data [ DataCapHAMTElement ]
+} representation tuple
+
+type DataCapHAMTElement union {
+  | DataCapHAMTLink "0"
+  | DataCapHAMTBucket "1"
+} representation keyed
+
+type DataCapHAMTLink &DataCapHAMT
+
+type DataCapHAMTBucket [ DataCapHAMTBucketEntry ]
+
+type DataCapHAMTBucketEntry struct {
+  key Address
+  value StoragePower # inline
+} representation tuple
+```
+
 ### SystemActor
 
+The system actor has an empty state


### PR DESCRIPTION
This builds on @willscott's excellent work on describing the basic forms in ipld-prime schemagen lingo @ https://github.com/filecoin-project/statediff/tree/master/types/gen and work I did with https://github.com/rvagg/car-to-schema to reverse-engineer the block forms in Filecoin extracts.

I've run out of steam today and there are 4 actors I haven't included yet.

I also haven't even touched the [message types](https://github.com/filecoin-project/statediff/tree/master/types/gen/messages) yet, but my understanding is that these are all serialized before being stored in `Params` in the `Message`s. So we have a dag-cbor-within-dag-cbor situation with them which kind of makes it difficult to explain the "links" with our schema language!

Lots more supporting information could be included around these schemas but we'd need to figure out what we're trying to do here that doesn't belong in the [specs](https://beta.spec.filecoin.io). Or maybe this work should eventually move there.

/cc @Satoshi-Kusumoto who's [working on a diagram of the chain](https://github.com/filecoin-project/devgrants/pull/129) I believe and may find this data useful.