### PR TITLE
feat: support filecoin hamt in same schema

### DIFF
--- a/data-structures/hashmap.md
+++ b/data-structures/hashmap.md
@@ -101,7 +101,7 @@ See [IPLD Schemas](../../schemas) for a definition of this format.
 type HashMapRoot struct {
   hashAlg Int
   bucketSize Int
-  hamt HashMapNode
+  hamt &HashMapNode
 }
 
 # Non-root node layout
@@ -113,7 +113,13 @@ type HashMapNode struct {
 type Element union {
   | &HashMapNode link
   | Bucket list
+  | FilecoinElement map
 } representation kinded
+
+type FilecoinElement union {
+  | &HashMapNode "0"
+  | Bucket "1"
+} representation keyed
 
 type Bucket [ BucketEntry ]
 


### PR DESCRIPTION
This is an attempt to support the Filecoin HAMT in the same schema. We should discuss the implications of this in the IPLD call because I’m not sure how well a double union will work in practice.