### PR TITLE
Graphsync v1.1.0, encoded as CBOR

### DIFF
--- a/block-layer/graphsync/graphsync.md
+++ b/block-layer/graphsync/graphsync.md
@@ -59,6 +59,8 @@ type GraphSyncNet interface {
 
 ## Network Messages
 
+### Protocol Version 1.1.0
+
 Graphsync network messages are encoded in DAG-CBOR. They have the following schema
 
 ```ipldsch
@@ -128,10 +130,10 @@ type GraphSyncRequest struct {
 }
 
 type GraphSyncResponse struct {
-    ID          GraphSyncRequestID          # the request id we are responding to
-    Status      GraphSyncResponseStatusCode # a status code.
-    Metadata    GraphSyncMetadata           # metadata about response
-    Extensions  GraphSyncExtensions         # side channel information
+  ID          GraphSyncRequestID          # the request id we are responding to
+  Status      GraphSyncResponseStatusCode # a status code.
+  Metadata    GraphSyncMetadata           # metadata about response
+  Extensions  GraphSyncExtensions         # side channel information
 }
 
 type GraphSyncBlock struct {
@@ -146,6 +148,41 @@ type GraphSyncMessage struct {
 }
 ```
 
+### Legacy Protocol Version 1.0.0
+
+An earlier version of graphsync encoded messages using protobufs
+
+```protobuf
+message GraphsyncMessage {
+
+  message Request {
+    int32 id = 1;       // unique id set on the requester side
+    bytes root = 2;     // a CID for the root node in the query
+    bytes selector = 3; // ipld selector to retrieve
+    map<string, bytes> extensions = 4; // side channel information
+    int32 priority = 5;	// the priority (normalized). default to 1
+    bool  cancel = 6;   // whether this cancels a request
+    bool  update = 7;   // whether this is an update to an in progress request
+  }
+
+  message Response {
+    int32 id = 1;     // the request id
+    int32 status = 2; // a status code.
+    map<string, bytes> extensions = 3;    // side channel information
+  }
+
+  message Block {
+  	bytes prefix = 1; // CID prefix (cid version, multicodec and multihash prefix (type + length)
+  	bytes data = 2;
+  }
+
+  // the actual data included in this message
+  bool completeRequestList    = 1; // This request list includes *all* requests, replacing outstanding requests.
+  repeated Request  requests  = 2; // The list of requests.
+  repeated Response responses = 3; // The list of responses.
+  repeated Block    data      = 4; // Blocks related to the responses
+}
+```
 
 ### Extensions
 

--- a/block-layer/graphsync/known_extensions.md
+++ b/block-layer/graphsync/known_extensions.md
@@ -25,6 +25,8 @@ The responder node will execute the selector query as it would normally. However
 
 ### Response Metadata
 
+***Legacy Graphsync Protocol 1.0.0 Only***
+
 Extension Name: `graphsync/response-metadata`
 
 What it does:


### PR DESCRIPTION
# Goals

Move graphsync to a CBOR based protocol instead of one based on protobuf

# Implementation

Graphsync messages should be valid IPLD data structures encoded in DAG-CBOR. I have constructed an IPLD schema to represent what they should look like.

I've also promoted Metadata out of an extension to a core part of the response message as opposed to an extension -- this is a frequent design issue with v1.0.0. 

# For Discussion

This is a first stab and I have many questions:
1. I've assumed all structs encoded as maps, rather than tuples, with no field renames -- is this too inefficient?
2. I've defined the extensions as a map of {string:Any} -- last I checked Any isn't a thing except when referring to link references. At the same time, I want to specify that an extension MUST be IPLD data which is why I did not use {string:bytes}.
3. I prefixed everything with GraphSync... which makes things a bit verbose. But also, Priority as a type on its own for example feels pretty general. Where GraphSyncPriority makes it clear it's a priority from graphsync's point of view.