### PR TITLE
dag-json: cleanup and fully specify reserved space

### DIFF
--- a/block-layer/codecs/dag-json.md
+++ b/block-layer/codecs/dag-json.md
@@ -44,11 +44,13 @@ See further discussion on [Floats in the Data Model](../../data-model.md#float-k
 
 ### Bytes
 
-The Bytes kind is represented as an object with `"bytes"` as key and a [Multibase](https://github.com/multiformats/multibase) Base64 encoded string as value. The Base64 encoding is the one described in [RFC 4648, section 4](https://tools.ietf.org/html/rfc4648#section-4) without padding, hence the Multibase prefix is `m`.
+The Bytes kind is represented as an object with `"bytes"` as key and a Base64 encoded string as value. The Base64 encoding is the one described in [RFC 4648, section 4](https://tools.ietf.org/html/rfc4648#section-4) without padding.
+
+_Note that a previous version of this specification and some implementations used a [Multibase](https://github.com/multiformats/multibase) prefix `m` for the bytes, this has been removed from the specification and the Base64 encoded bytes **should not** be prefixed._
 
 
 ```javascript
-{"/": { "bytes": String /* Multibase Base64 encoded binary */ }}
+{"/": { "bytes": String /* Base64 encoded binary */ }}
 ```
 
 ### Links
@@ -69,7 +71,7 @@ Maps with the first key of `"/"` are considered the **reserved namespace** in DA
 The two forms used in the reserved namespace are:
 
  * **CID**: a map with the single key `"/"`, whose value is a string, must contain a valid CIDv0 in Base58 string form **or** CIDv1 in Base32 string form. Such a map whose string does not properly represent such a CID should should be rejected as invalid DAG-JSON.
- * **Bytes**: A map with the single key `"/"`, whose value is a map with the single key `"bytes"`, whose value is a string, must contain a valid multibase Base64 encoded byte array. Such a construction whose string does not properly represent a multibase base64 encoded byte array should be rejected as invalid DAG-JSON.
+ * **Bytes**: A map with the single key `"/"`, whose value is a map with the single key `"bytes"`, whose value is a string, must contain a valid Base64 encoded byte array. Such a construction whose string does not properly represent a Base64 encoded byte array should be rejected as invalid DAG-JSON.
 
 #### Parse rejection modes in the reserved namespace
 
@@ -106,7 +108,8 @@ There is no mechanism for escaping otherwise valid JSON data that takes these fo
 
 The legacy **[ipld-dag-json](https://github.com/ipld/js-ipld-dag-json)** implementation adheres to this specification, with the following caveats:
  * The reserved namespace rules above are not strictly applied. Decoding maps with the forms of Bytes and Links but with additional entries in inner or outer maps will be successfuly decoded as Bytes or Links but the extraneous entries will be ignored.
+ * Bytes are encoded with their Multibase Base64 prefix `m` as per a previous version of this specification.
 
 ### Go
 
-**[go-ipld-prime]** adheres to this specification.
+**[go-ipld-prime]** adheres to this specification except for the sorting of map keys, which retain their assembled order.

--- a/block-layer/codecs/dag-json.md
+++ b/block-layer/codecs/dag-json.md
@@ -112,4 +112,6 @@ The legacy **[ipld-dag-json](https://github.com/ipld/js-ipld-dag-json)** impleme
 
 ### Go
 
-**[go-ipld-prime]** adheres to this specification except for the sorting of map keys, which retain their assembled order.
+**[go-ipld-prime]** adheres to this specification with the following caveats:
+ * Map keys are not sorted, they retain their assembled order.
+ * Encoded forms are pretty-printed, i.e. do not have whitespace stripped.

--- a/block-layer/codecs/dag-json.md
+++ b/block-layer/codecs/dag-json.md
@@ -4,9 +4,17 @@
 
 DAG-JSON supports the full [IPLD Data Model](../../data-model-layer/data-model.md).
 
+DAG-JSON uses the [JavaScript Object Notation (JSON)] data format, defined by [RFC 8259](https://tools.ietf.org/html/rfc8259).
+
 ## Format
 
-### Serialization
+The native JSON IPLD format is called DAG-JSON to disambiguate it from regular JSON. Most simple JSON objects are valid DAG-JSON. The primary differences are:
+
+ * Bytes and Links are supported with special use of single-key (`"/"`) map.
+ * In limited cases, maps with the key `"/"` other than those used to encode Bytes and Links, are disallowed.
+ * Maps are sorted by key.
+
+## Serialization
 
 Codec implementors **MUST** do the following in order to ensure hashes consistently match for the same block data.
 
@@ -16,24 +24,25 @@ Codec implementors **MUST** do the following in order to ensure hashes consisten
 This produces the most compact and consistent representation which will ensure that two codecs
 producing the same data end up with matching block hashes.
 
-### Natively supported kinds
+## Supported Kinds
 
-All kinds of the IPLD Data Model except Bytes and Link are supported natively by JSON.
+All [IPLD Data Model Kinds](../../data-model.md#kinds) except Bytes and Link are supported natively by JSON.
 
-#### Numbers
+Bytes and Links use extensions specific to DAG-JSON. They are implemented as an map, where the single key is a slash (`"/"`) and the value contains the kind's data.
 
-Numbers are a special case. JSON only has a single number type, though many dynamically typed programming languages (e.g. Python, Ruby, PHP) distinguish between integers and floats when parsing JSON. A number consisting of an optional leading sign and only digits is parsed as integer, if it contains a decimal point, it's parsed as a float. In DAG-JSON the same method is used to represent integers and floats.
+### Numbers
 
-Contrary to popular belief, JSON as a format supports Big Integers. It's only
-JavaScript itself that has trouble with them. This means JS implementations
-of DAG-JSON can't use the native JSON parser and serializer if integers bigger
-than `2^53 - 1` should be supported.
+JSON only has a single number type. Many dynamically typed programming languages (e.g. Python, Ruby, PHP) distinguish between integers and floats when parsing JSON. JavaScript does not since all numbers are represented internally as IEEE 754 floats. A JSON number consisting of an optional leading sign (`-`) and only digits is parsed as integer, if it contains a decimal point, it's parsed as a float. DAG-JSON the same method is used to represent integers and floats.
 
-### Other kinds
+Data Model floats that do not have a fractional component should be encoded without a decimal point, and will therefore not be distinguishable from an integer during round-trip.
 
-The non-natively supported kinds are wrapped in an object, where the key is a slash (`"/"`) and the value is the actual kind.
+Contrary to popular belief, JSON as a format supports Big Integers. It's only JavaScript itself that has trouble with them. This means JS implementations of DAG-JSON can't use the native JSON parser and serializer if integers bigger than `2^53 - 1` need to be supported.
 
-#### Bytes kind
+`Infinity`, `NaN` and `-Infinity` are not natively supported by JSON and are not supported by the IPLD Data Model.
+
+See further discussion on [Floats in the Data Model](../../data-model.md#float-kind), including a recommendation to avoid floats where possible when producing and consuming content addressed data.
+
+### Bytes
 
 The Bytes kind is represented as an object with `"bytes"` as key and a [Multibase](https://github.com/multiformats/multibase) Base64 encoded string as value. The Base64 encoding is the one described in [RFC 4648, section 4](https://tools.ietf.org/html/rfc4648#section-4) without padding, hence the Multibase prefix is `m`.
 
@@ -42,9 +51,9 @@ The Bytes kind is represented as an object with `"bytes"` as key and a [Multibas
 {"/": { "bytes": String /* Multibase Base64 encoded binary */ }}
 ```
 
-#### Link kind
+### Links
 
-A link is represented as a base encoded CID. CIDv0 and CIDv1 are encoded differently.
+A Link kind is represented as a base encoded CID. CIDv0 and CIDv1 are encoded differently.
 
  - CIDv1 is represented as a Multibase Base32 encoded string. The Base32 encoding is the one described in [RFC 4648, section 6](https://tools.ietf.org/html/rfc4648#section-6) without padding, hence the Multibase prefix is `b`.
  - CIDv0 is represented in its only possible Base58 encoding. The Base58 encoding is the one described in [Base58 draft](https://tools.ietf.org/html/draft-msporny-base58).
@@ -52,3 +61,39 @@ A link is represented as a base encoded CID. CIDv0 and CIDv1 are encoded differe
 ```javascript
 {"/": String /* Base58 encoded CIDv0 or Multibase Base32 encoded CIDv1 */}
 ```
+
+### The Reserved Namespace
+
+Maps with the first key of `"/"` are considered the **reserved namespace** in DAG-JSON as they are used to represent Bytes and Links. There are special rules that restrict certain data forms from being properly encoded in DAG-JSON. These rules allow for the clean representation of Bytes and Links as well as efficient operation of tokenizing decoders. A tokenizing decoder should not need to buffer and back-track more than 4 tokens upon detection of a map that is not properly encoding Links or Bytes.
+
+Specifically, data with the following forms are strictly not valid DAG-JSON and should be rejected by encoders and decoders:
+
+ * Maps with more than one key, where the first key is `"/"` and its value is a string. e.g. `{"/":"foo","bar":"baz"}`.
+   - Where a key exists that sorts before `"/"`, the map is valid, e.g. `{"0bar":"baz","/":"foo"}`.
+   - Where the value of the `"/"` entry is not a string, the map is valid, e.g. `{"/":true,"bar":"baz"}`
+ * Maps where the first key is `"/"` and its value is a map with more than one key where the first key of the inner map is `"bytes"` whose value is a string. e.g. `{"/":{"bytes":"foo","bar":"baz"}}`.
+   * Where a key exists in the inner map that sorts before `"bytes"`, the map is valid, e.g. `{"/":{"abar":"baz","bytes":"foo"}}`.
+   * Where the value of the inner map's `"bytes"` entry is not a string, the map is valid, e.g. `{"/":{"bytes":true},"bar":"baz"}`.
+ * Maps with more than one key, where the first key is `"/"` and its value is a map where the first key of the inner map is `"bytes"` whose value is a string. e.g. `{"/":{"bytes":"foo"},"bar":"baz"}`.
+   - Where a key exists that sorts before `"/"`, the map is valid, e.g. `{"0bar":"baz","/":{"bytes":"foo"}}`.
+   - Where the value of the `"bytes"` entry in the inner map is not a string, the map is valid, e.g. `{"/":{"bytes":true},"bar":"baz"}`
+
+Further:
+
+ * A map with the single key `"/"`, whose value is a string, must contain a valid CIDv0 base58 string or CIDv1 base32 string. Such a map whose string does not properly represent such a CID should should be rejected as invalid DAG-CBOR.
+ * A map with the single key `"/"`, whose value is a map with the single key `"bytes"`, whose value is a string, must contain a valid multibase base64 encoded byte array. Such a construction whose string does not properly represent a multibase base64 encoded byte array should be rejected as invalid DAG-CBOR.
+
+There is no mechanism for escaping otherwise valid JSON data that takes these forms. For this reason, it is recommended that the `"/"` key should be avoided in Data Model maps where DAG-JSON may be used in order to avoid such conflicts.
+
+## Implementations
+
+### JavaScript
+
+**[@ipld/dag-json](https://github.com/ipld/js-dag-cbor)**, for use with [multiformats] adheres to this specification.
+
+The legacy **[ipld-dag-json](https://github.com/ipld/js-ipld-dag-cbor)** implementation adheres to this specification, with the following caveats:
+ * The reserved namespace rules above are not strictly applied. Decoding maps with the forms of Bytes and Links but with additional entries in inner or outer maps will be successfuly decoded as Bytes or Links but the extraneous entries will be ignored.
+
+### Go
+
+**[go-ipld-prime]** adheres to this specification.

--- a/block-layer/codecs/dag-json.md
+++ b/block-layer/codecs/dag-json.md
@@ -34,7 +34,7 @@ Bytes and Links use extensions specific to DAG-JSON. They are implemented as an 
 
 JSON only has a single number type. Many dynamically typed programming languages (e.g. Python, Ruby, PHP) distinguish between integers and floats when parsing JSON. JavaScript does not since all numbers are represented internally as IEEE 754 floats. A JSON number consisting of an optional leading sign (`-`) and only digits is parsed as integer, if it contains a decimal point, it's parsed as a float. DAG-JSON the same method is used to represent integers and floats.
 
-Data Model floats that do not have a fractional component should be encoded without a decimal point, and will therefore not be distinguishable from an integer during round-trip.
+Data Model floats that do not have a fractional component should be encoded **with** a decimal point, and will therefore be distinguishable from an integer during round-trip. (Note that since JavaScript still cannot distinguish a float from an integer where the number has no fractional component, this rule will not impact JavaScript encoding or decoding).
 
 Contrary to popular belief, JSON as a format supports Big Integers. It's only JavaScript itself that has trouble with them. This means JS implementations of DAG-JSON can't use the native JSON parser and serializer if integers bigger than `2^53 - 1` need to be supported.
 
@@ -66,22 +66,35 @@ A Link kind is represented as a base encoded CID. CIDv0 and CIDv1 are encoded di
 
 Maps with the first key of `"/"` are considered the **reserved namespace** in DAG-JSON as they are used to represent Bytes and Links. There are special rules that restrict certain data forms from being properly encoded in DAG-JSON. These rules allow for the clean representation of Bytes and Links as well as efficient operation of tokenizing decoders. A tokenizing decoder should not need to buffer and back-track more than 4 tokens upon detection of a map that is not properly encoding Links or Bytes.
 
-Specifically, data with the following forms are strictly not valid DAG-JSON and should be rejected by encoders and decoders:
+The two forms used in the reserved namespace are:
 
- * Maps with more than one key, where the first key is `"/"` and its value is a string. e.g. `{"/":"foo","bar":"baz"}`.
-   - Where a key exists that sorts before `"/"`, the map is valid, e.g. `{"0bar":"baz","/":"foo"}`.
-   - Where the value of the `"/"` entry is not a string, the map is valid, e.g. `{"/":true,"bar":"baz"}`
- * Maps where the first key is `"/"` and its value is a map with more than one key where the first key of the inner map is `"bytes"` whose value is a string. e.g. `{"/":{"bytes":"foo","bar":"baz"}}`.
-   * Where a key exists in the inner map that sorts before `"bytes"`, the map is valid, e.g. `{"/":{"abar":"baz","bytes":"foo"}}`.
-   * Where the value of the inner map's `"bytes"` entry is not a string, the map is valid, e.g. `{"/":{"bytes":true},"bar":"baz"}`.
- * Maps with more than one key, where the first key is `"/"` and its value is a map where the first key of the inner map is `"bytes"` whose value is a string. e.g. `{"/":{"bytes":"foo"},"bar":"baz"}`.
-   - Where a key exists that sorts before `"/"`, the map is valid, e.g. `{"0bar":"baz","/":{"bytes":"foo"}}`.
-   - Where the value of the `"bytes"` entry in the inner map is not a string, the map is valid, e.g. `{"/":{"bytes":true},"bar":"baz"}`
+ * **CID**: a map with the single key `"/"`, whose value is a string, must contain a valid CIDv0 in Base58 string form **or** CIDv1 in Base32 string form. Such a map whose string does not properly represent such a CID should should be rejected as invalid DAG-JSON.
+ * **Bytes**: A map with the single key `"/"`, whose value is a map with the single key `"bytes"`, whose value is a string, must contain a valid multibase Base64 encoded byte array. Such a construction whose string does not properly represent a multibase base64 encoded byte array should be rejected as invalid DAG-JSON.
 
-Further:
+#### Parse rejection modes in the reserved namespace
 
- * A map with the single key `"/"`, whose value is a string, must contain a valid CIDv0 base58 string or CIDv1 base32 string. Such a map whose string does not properly represent such a CID should should be rejected as invalid DAG-CBOR.
- * A map with the single key `"/"`, whose value is a map with the single key `"bytes"`, whose value is a string, must contain a valid multibase base64 encoded byte array. Such a construction whose string does not properly represent a multibase base64 encoded byte array should be rejected as invalid DAG-CBOR.
+Data with the following forms are **strictly not valid DAG-JSON** and should be rejected by encoders and decoders:
+
+***Maps with more than one key, where the first key is `"/"` and its value is a string.***
+
+e.g. `{"/":"foo","bar":"baz"}`
+
+ * Where a key exists that sorts before `"/"`, the map is valid, e.g. `{"0bar":"baz","/":"foo"}`.
+ * Where the value of the `"/"` entry is not a string, the map is valid, e.g. `{"/":true,"bar":"baz"}`.
+
+***Maps where the first key is `"/"` and its value is a map with more than one key where the first key of the inner map is `"bytes"` whose value is a string.***
+
+e.g. `{"/":{"bytes":"foo","bar":"baz"}}`
+
+ * Where a key exists in the inner map that sorts before `"bytes"`, the map is valid, e.g. `{"/":{"abar":"baz","bytes":"foo"}}`.
+ * Where the value of the inner map's `"bytes"` entry is not a string, the map is valid, e.g. `{"/":{"bytes":true},"bar":"baz"}`.
+ 
+***Maps with more than one key, where the first key is `"/"` and its value is a map where the first key of the inner map is `"bytes"` whose value is a string.***
+
+e.g. `{"/":{"bytes":"foo"},"bar":"baz"}`
+
+ * Where a key exists that sorts before `"/"`, the map is valid, e.g. `{"0bar":"baz","/":{"bytes":"foo"}}`.
+ * Where the value of the `"bytes"` entry in the inner map is not a string, the map is valid, e.g. `{"/":{"bytes":true},"bar":"baz"}`.
 
 There is no mechanism for escaping otherwise valid JSON data that takes these forms. For this reason, it is recommended that the `"/"` key should be avoided in Data Model maps where DAG-JSON may be used in order to avoid such conflicts.
 
@@ -89,9 +102,9 @@ There is no mechanism for escaping otherwise valid JSON data that takes these fo
 
 ### JavaScript
 
-**[@ipld/dag-json](https://github.com/ipld/js-dag-cbor)**, for use with [multiformats] adheres to this specification.
+**[@ipld/dag-json](https://github.com/ipld/js-dag-json)**, for use with [multiformats](https://github.com/multiformats/js-multiformats) adheres to this specification.
 
-The legacy **[ipld-dag-json](https://github.com/ipld/js-ipld-dag-cbor)** implementation adheres to this specification, with the following caveats:
+The legacy **[ipld-dag-json](https://github.com/ipld/js-ipld-dag-json)** implementation adheres to this specification, with the following caveats:
  * The reserved namespace rules above are not strictly applied. Decoding maps with the forms of Bytes and Links but with additional entries in inner or outer maps will be successfuly decoded as Bytes or Links but the extraneous entries will be ignored.
 
 ### Go


### PR DESCRIPTION
I've been working ok figuring out how to codify the rules that we discussed sometime last meeting .. during some meeting. I can't find the particular meeting by looking at the minutes in https://github.com/ipld/team-mgmt so I'm doing this from memory. But the main points were:

* Strictly only allow certain forms in the `{"/":...}` namespace so that tokenizing parsers didn't have to buffer and unroll too much data but can quickly reject form without getting too deep.
* ~~Remove the multibase prefix from the encoded bytes.~~

After working through some of this, I've flipped on my opinion of the second point and would rather it stay as proper multibase, even if it's still strictly base64. It adds clarity and there's scope for using this for further validation if we want to. It's a single byte and I think it increases the clarity and reduces the number of edge cases. So I haven't included that change here, but discussion is welcome if you feel strongly!

The bit to pay most attention to below is "The Reserved Namespace" where I've tried to enumerate the rules. It turns out to be quite hard to explain it with crystal clarity, but that could be me so suggestions welcome!

Along with this, as exploration, I've been working on a version of JS DAG-JSON that does tokenized decoding and uses the same base encoder/decoder as the new JS DAG-CBOR codec, just by swapping out the backend. There's some consistency benefits here in having the same code paths and same affordances for applying data model strictness. Still uncertain whether I'll actually propose that we merge this, although I did uncover some bugs in the current implementation in the process, but the code is here: https://github.com/ipld/js-dag-json/compare/rvagg/cborg (see the innards of `DagJsonTokenizer` for the token parsing rules that arise from the reserved space rules).