### PR TITLE
Remove less bugs with string as bytes section

### DIFF
--- a/data-model-layer/data-model.md
+++ b/data-model-layer/data-model.md
@@ -166,10 +166,6 @@ programming language itself, to do so instead.
 Applications that only serialize valid UTF8 in string values will have fewer compatibility
 issues than applications that do not.
 
-Codec implementations that can de-serialization and roundtrip
-arbitrary byte data in strings will see fewer bug reports from people working with data produced by
-applications that serialize arbitrary byte data into strings.
-
 The [Unicode Normalization Form](http://www.unicode.org/reports/tr15/) should be NFC.
 
 #### Bytes kind


### PR DESCRIPTION
Removing the section about less bugs in regards to handling strings as bytes.
This just isn't true. I know of two instances where there were bug reports about strings,
both were discovered in Rust implementations (where strings are UTF-8) and were
reported against (and fixed) on the Go implementations.