### PR TITLE
fix: byteprefix union representation AST form fix

### DIFF
--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -431,9 +431,7 @@ type UnionRepresentation_Inline struct {
 ## byteprefix is an invalid representation for any union that contains a type
 ## that does not have a bytes representation.
 ##
-type UnionRepresentation_BytePrefix struct {
-	discriminantTable {TypeName:Int}
-}
+type UnionRepresentation_BytePrefix {TypeName:Int}
 
 ## TypeStruct describes a type which has a group of fields of varying Type.
 ## Each field has a name, which is used to access its value, similarly to

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -355,19 +355,9 @@
 			}
 		},
 		"UnionRepresentation_BytePrefix": {
-			"kind": "struct",
-			"fields": {
-				"discriminantTable": {
-					"type": {
-						"kind": "map",
-						"keyType": "TypeName",
-						"valueType": "Int"
-					}
-				}
-			},
-			"representation": {
-				"map": {}
-			}
+			"kind": "map",
+			"keyType": "TypeName",
+			"valueType": "Int"
 		},
 		"TypeStruct": {
 			"kind": "struct",


### PR DESCRIPTION
discovered while trying to use via TypeScript @ https://github.com/ipld/js-ipld-schema/pull/37 -> https://github.com/rvagg/js-ipld-schema-validator/pull/4