### PR TITLE
feat: allow inline link definitions for kinded unions

### DIFF
--- a/schemas/schema-schema.ipldsch
+++ b/schemas/schema-schema.ipldsch
@@ -378,7 +378,15 @@ type UnionRepresentation union {
 ##
 ## The referenced type must of course produce the RepresentationKind it's
 ## matched with!
-type UnionRepresentation_Kinded {RepresentationKind:TypeName}
+type UnionRepresentation_Kinded {RepresentationKind:KindedType}
+
+## "KindedType" is used to allow inline link definitions within a kinded union
+## as a shorthand rather than requiring all links be defined as a separate type
+## before used within a kinded union.
+type KindedType union {
+  | TypeName "string"
+  | TypeLink "link"
+} representation kinded
 
 ## "Keyed" union representations will encode as a map, where the map has
 ## exactly one entry, the key string of which will be used to look up the name

--- a/schemas/schema-schema.ipldsch.json
+++ b/schemas/schema-schema.ipldsch.json
@@ -308,7 +308,16 @@
 		"UnionRepresentation_Kinded": {
 			"kind": "map",
 			"keyType": "RepresentationKind",
-			"valueType": "TypeName"
+			"valueType": "KindedType"
+		},
+		"KindedType": {
+			"kind": "union",
+			"representation": {
+				"kinded": {
+					"string": "TypeName",
+					"link": "TypeLink"
+				}
+			}
 		},
 		"UnionRepresentation_Keyed": {
 			"kind": "map",


### PR DESCRIPTION
e.g.

```
type Foo union {
  | &Blip link
  | Blop string
} representation kinded
```

rather than having to `type BlipLink &Blip` before using it in a kinded union.

---

I've been using this pattern already, e.g. https://github.com/ipld/specs/blob/9bab36f7c256ae8ff14e0190ff0327e631ef2e15/data-structures/hashmap.md#L113-L116

I think I assumed we had this locked in but I guess we never got it into schema-schema. Without this, to use a link to another type you've defined, you have to make a new link type for it `type HashMapNodeLink &HashMapNode`.