### PR TITLE
feat: redirect to ipld.io/specs/, with some specifics

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -52,5 +52,8 @@ module.exports = {
   extendMarkdown: md => {
     // use more markdown-it plugins!
     md.use(linkfix)
-  }
+  },
+  plugins: [
+    require('./redirects.js')
+  ]
 }

--- a/.vuepress/redirect_template.html
+++ b/.vuepress/redirect_template.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>This page has moved...</title>
+  <meta http-equiv="refresh" content="7;url={{redirectUrl}}">
+  <link rel="canonical" href="{{redirectUrl}}">
   <style type="text/css">
     body {
       font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
@@ -22,7 +24,7 @@
   <p>This page has moved to <b><a href="{{redirectUrl}}">{{redirectUrl}}</a></b>. You will be redirected in 5 seconds.</p>
   <script>
     setTimeout(() => {
-      location.href = '{{redirectUrl}}'
+      location.replace('{{redirectUrl}}')
     }, 5000)
   </script>
 </body>

--- a/.vuepress/redirect_template.html
+++ b/.vuepress/redirect_template.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>This page has moved...</title>
+  <style type="text/css">
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      font-size: 16px;
+      color: #2c3e50
+    }
+    a {
+      color: #3eaf7c;
+      font-weight: 500;
+      text-decoration: none
+    }
+  </style>
+</head>
+<body>
+  <p>This page has moved to <b><a href="{{redirectUrl}}">{{redirectUrl}}</a></b>. You will be redirected in 5 seconds.</p>
+  <script>
+    setTimeout(() => {
+      location.href = '{{redirectUrl}}'
+    }, 5000)
+  </script>
+</body>
+</html>

--- a/.vuepress/redirects.js
+++ b/.vuepress/redirects.js
@@ -1,0 +1,51 @@
+const path = require('path')
+const fs = require('fs').promises
+
+const defaultRedirect = 'https://ipld.io/specs/'
+
+const redirects = [
+  ['/block-layer/codecs/index.html', 'https://ipld.io/specs/codecs/'],
+  ['/block-layer/codecs/dag-cbor.html', 'https://ipld.io/specs/codecs/dag-cbor/'],
+  ['/block-layer/codecs/dag-json.html', 'https://ipld.io/specs/codecs/dag-json/'],
+  ['/block-layer/codecs/dag-jose.html', 'https://ipld.io/specs/codecs/dag-jose/'],
+  ['/block-layer/codecs/dag-pb.html', 'https://ipld.io/specs/codecs/dag-pb/'],
+  ['/block-layer/content-addressable-archives.html', 'https://ipld.io/specs/transport/car/'],
+  ['/block-layer/graphsync/known_extensions.html', 'https://ipld.io/specs/transport/graphsync/known_extensions/'],
+  ['/block-layer/graphsync/graphsync.html', 'https://ipld.io/specs/transport/graphsync/'],
+  ['/concepts/type-theory-glossary.html', 'https://ipld.io/design/concepts/type-theory-glossary/'],
+  ['/data-model-layer/pathing.html', 'https://ipld.io/docs/data-model/pathing/'],
+  [/^\/data-structures\/ethereum/, '/data-structures/ethereum/'],
+  [/^\/data-structures\/filecoin/, 'https://github.com/ipld/ipld/tree/master/_legacy/specs/data-structures/filecoin'],
+  ['/data-structures/flexible-byte-layout.html', 'https://ipld.io/specs/advanced-data-layouts/fbl/'],
+  ['/data-structures/hashmap.html', 'https://ipld.io/specs/advanced-data-layouts/hamt/'],
+  [/^\/design\/history\/exploration-reports/, 'https://github.com/ipld/ipld/tree/master/notebook/exploration-reports'],
+  [/^\/design\//, 'https://ipld.io/design/'],
+  ['/design/libraries/nodes-and-kinds.html', 'https://ipld.io/design/libraries/nodes-and-kinds/'],
+  [/^\/schemas\//, 'https://ipld.io/docs/schemas/'],
+  [/^\/selectors\//, 'https://ipld.io/specs/selectors/']
+]
+
+module.exports = (options = {}, context) => ({
+  generated: async (paths) => {
+    const redirectTemplate = await fs.readFile(path.join(__dirname, 'redirect_template.html'), 'utf8')
+    const queue = []
+
+    for (const pathAbs of paths) {
+      const pathRel = pathAbs.replace(path.join(__dirname, 'dist'), '')
+      let redir = defaultRedirect
+      for (const [from, to] of redirects) {
+        if (typeof from === 'string' && pathRel.startsWith(from)) {
+          redir = to
+          break
+        } else if (from instanceof RegExp && from.test(pathRel)) {
+          redir = to
+          break
+        }
+      }
+      redirPage = redirectTemplate.replace(/\{\{redirectUrl\}\}/g, redir)
+      queue.push(fs.writeFile(pathAbs, redirPage, 'utf8'))
+    }
+
+    await Promise.all(queue)
+  }
+})


### PR DESCRIPTION
Uses a (custom) vuepress plugin to overwrite all generated pages with a new redirect
html that does a JS redirect in 5 seconds after explaining it. Some pages have
specific redirects to their new versions, some are done in groups (e.g.
schemas pages all go to /specs/schemas/), and the remainder just go to
ipld.io/specs.

Closes: https://github.com/protocol/infra/issues/818

---

I unarchived this repo to get this in. After merge, the Github Action in here will build the site and push to gh-pages which will replace the old HTML with this new one. I'll re-archive after merge.

Most interesting 2 pieces in this PR are the redirect template, and the list of redirects in the array. I've mostly plucked out important pages and easy redirects. Many are just going to get a general redirect to ipld.io/specs though.

---
e.g. of the dag-cbor page:

<img width="743" alt="Screenshot 2022-06-28 at 4 08 29 pm" src="https://user-images.githubusercontent.com/495647/176105681-320b4924-5eaf-4ff2-9f09-86e9281c9fcd.png">
